### PR TITLE
Refactor SDK documentation to update package name from `kaleidoswap-s…

### DIFF
--- a/mintlify-docs/sdk/api-reference.mdx
+++ b/mintlify-docs/sdk/api-reference.mdx
@@ -1,726 +1,266 @@
 ---
 title: 'Client Reference'
-description: 'Complete method reference for the KaleidoSwap SDK — MakerClient and RlnClient'
----
-
-## Quick Navigation
-
-This reference documents both the **Maker API Client** and **RLN API Client**. Use these links to jump to each section:
-
-- **[Maker API Client](#makerclient-client-maker)** — Market data, orders, swaps, LSPS1, and WebSocket streaming
-- **[RLN API Client](#rlnclient-client-rln)** — Wallet, channels, invoices, and node operations
-
-For compatibility details, see the [Maker API Compatibility](./maker-api-compatibility) and [RLN API Compatibility](./rln-api-compatibility) pages.
-
+description: 'Reference for KaleidoClient, MakerClient, and RlnClient'
 ---
 
 ## Client Initialization
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient, LogLevel } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: 'https://api.regtest.kaleidoswap.com',
-  nodeUrl: 'http://localhost:3001',  // optional
-  apiKey: 'your-api-key',           // optional
-  timeout: 30,                       // optional, seconds
-  maxRetries: 3,                     // optional
-  cacheTtl: 60,                      // optional, seconds
+  nodeUrl: 'http://localhost:3001',
+  apiKey: process.env.KALEIDO_API_KEY,
+  timeout: 30,
+  logLevel: LogLevel.INFO,
 });
 
-client.hasNode();  // boolean -- check if nodeUrl is configured
-client.maker;      // MakerClient instance
-client.rln;        // RlnClient instance
+client.hasMaker(); // boolean
+client.hasNode();  // boolean
+client.maker;      // MakerClient
+client.rln;        // RlnClient
 ```
 
 ```python Python
-from kaleidoswap_sdk import KaleidoClient
+import logging
+from kaleido_sdk import KaleidoClient
 
 client = KaleidoClient.create(
     base_url="https://api.regtest.kaleidoswap.com",
-    node_url="http://localhost:3001",  # optional
-    api_key="your-api-key",            # optional
-    timeout=30.0,                       # optional
-    max_retries=3,                      # optional
-    cache_ttl=60,                       # optional
+    node_url="http://localhost:3001",
+    api_key=None,
+    timeout=30.0,
+    max_retries=3,
+    cache_ttl=60,
+    log_level=logging.INFO,
 )
 
 client.has_node()  # bool
-client.maker       # MakerClient instance
-client.rln         # RlnClient instance
+client.maker       # MakerClient
+client.rln         # RlnClient, raises if node_url is missing
 ```
 </CodeGroup>
-
----
 
 ## MakerClient (`client.maker`)
 
-All market, order, swap, and LSPS1 operations are accessed via `client.maker`.
+### Market Data
 
-### Market Operations
-
-#### `listAssets` / `list_assets`
-
-List all available assets.
-
-<CodeGroup>
-```typescript TypeScript
-const response = await client.maker.listAssets();
-// Returns: MarketListAssetsResponse
-```
-
-```python Python
-response = await client.maker.list_assets()
-# Returns: AssetsResponse
-```
-</CodeGroup>
-
-#### `listPairs` / `list_pairs`
-
-List all available trading pairs with min/max limits and supported layers.
+| TypeScript | Python | Notes |
+|------------|--------|-------|
+| `listAssets()` | `list_assets()` | List all assets |
+| `listPairs()` | `list_pairs()` | List all trading pairs |
+| `getQuote(body)` | `get_quote(body)` | Request a quote |
+| `getPairRoutes(body)` | `get_pair_routes(pair_ticker)` | TS accepts a request body; Python accepts a pair ticker like `"BTC/USDT"` |
+| `getMarketRoutes(body)` | `get_market_routes(body)` | Discover market routes |
 
 <CodeGroup>
 ```typescript TypeScript
-const response = await client.maker.listPairs();
-// Returns: ListPairsResponse
-```
+import { KaleidoClient, Layer } from 'kaleido-sdk';
 
-```python Python
-response = await client.maker.list_pairs()
-# Returns: TradingPairsResponse
-```
-</CodeGroup>
+const client = KaleidoClient.create();
 
-#### `getQuote` / `get_quote`
-
-Get a price quote for a swap.
-
-<CodeGroup>
-```typescript TypeScript
+const assets = await client.maker.listAssets();
+const pairs = await client.maker.listPairs();
 const quote = await client.maker.getQuote({
-  from_asset: { asset_id: 'BTC', layer: 'BTC_LN', amount: 100000 },
-  to_asset: { asset_id: 'USDT', layer: 'RGB_LN' }
+  from_asset: { asset_id: 'BTC', layer: Layer.BTC_LN, amount: 100000 },
+  to_asset: { asset_id: 'USDT', layer: Layer.RGB_LN },
 });
-// Returns: GetQuoteResponse
 ```
 
 ```python Python
-from kaleidoswap_sdk import Layer, PairQuoteRequest, SwapLegInput
+from kaleido_sdk import KaleidoClient, Layer, PairQuoteRequest, SwapLegInput
 
-quote = await client.maker.get_quote(PairQuoteRequest(
-    from_asset=SwapLegInput(asset_id="BTC", layer=Layer.btc_ln, amount=100000),
-    to_asset=SwapLegInput(asset_id="USDT", layer=Layer.rgb_ln)
-))
-# Returns: PairQuoteResponse
+client = KaleidoClient.create()
+
+assets = await client.maker.list_assets()
+pairs = await client.maker.list_pairs()
+quote = await client.maker.get_quote(
+    PairQuoteRequest(
+        from_asset=SwapLegInput(asset_id="BTC", layer=Layer.BTC_LN, amount=100000),
+        to_asset=SwapLegInput(asset_id="USDT", layer=Layer.RGB_LN),
+    )
+)
 ```
 </CodeGroup>
 
-#### `getPairRoutes` / `get_pair_routes`
+### Swap Orders
 
-Get available routes for a trading pair.
+| TypeScript | Python | Notes |
+|------------|--------|-------|
+| `createSwapOrder(body)` | `create_swap_order(body)` | Create a swap order from a quote |
+| `getSwapOrderStatus(body)` | `get_swap_order_status(body)` | Fetch current order status |
+| `getOrderHistory(params?)` | `get_order_history(...)` | History with optional filters |
+| `getOrderAnalytics()` | `get_order_analytics()` | Aggregate order analytics |
+| `submitRateDecision(body)` | `submit_rate_decision(body)` | Accept or reject a refreshed rate |
+| `waitForSwapCompletion(orderId, options)` | `wait_for_swap_completion(order_id, options)` | Poll until terminal state |
 
-<CodeGroup>
-```typescript TypeScript
-const routes = await client.maker.getPairRoutes({ /* GetPairRoutesRequest */ });
-// Returns: GetPairRoutesResponse
-```
-
-```python Python
-from kaleidoswap_sdk import GetPairRoutesRequest
-
-routes = await client.maker.get_pair_routes(GetPairRoutesRequest(...))
-# Returns: list[SwapRoute]
-```
-</CodeGroup>
-
-#### `getMarketRoutes` / `get_market_routes`
-
-Discover routes across the market.
+`waitForSwapCompletion` in TypeScript requires `accessToken` inside `options`. The Python helper currently polls with just `order_id`.
 
 <CodeGroup>
 ```typescript TypeScript
-const routes = await client.maker.getMarketRoutes({ /* RoutesRequest */ });
-// Returns: RoutesResponse
-```
-
-```python Python
-from kaleidoswap_sdk import RoutesRequest
-
-routes = await client.maker.get_market_routes(RoutesRequest(...))
-# Returns: RoutesResponse
-```
-</CodeGroup>
-
----
-
-### Swap Order Operations
-
-#### `createSwapOrder` / `create_swap_order`
-
-Create a new swap order from a quote.
-
-<CodeGroup>
-```typescript TypeScript
-// Use the quote's from_asset and to_asset (SwapLeg) — they already have amounts from the quote
 const order = await client.maker.createSwapOrder({
   rfq_id: quote.rfq_id,
   from_asset: quote.from_asset,
   to_asset: quote.to_asset,
-  receiver_address: 'lnbc1...',
-  min_onchain_conf: 1
+  receiver_address: {
+    address: 'demo-receiver-address',
+    format: 'BOLT11',
+  },
 });
-// Returns: CreateSwapOrderResponse (order_id, deposit_address, status)
-```
 
-```python Python
-from kaleidoswap_sdk import CreateSwapOrderRequest
-
-# Use the quote's from_asset and to_asset (SwapLeg) — they already have amounts from the quote
-order = await client.maker.create_swap_order(CreateSwapOrderRequest(
-    rfq_id=quote.rfq_id,
-    from_asset=quote.from_asset,
-    to_asset=quote.to_asset,
-    receiver_address="lnbc1...",
-    min_onchain_conf=1
-))
-# Returns: CreateSwapOrderResponse
-```
-</CodeGroup>
-
-#### `getSwapOrderStatus` / `get_swap_order_status`
-
-Get the current status of a swap order.
-
-<CodeGroup>
-```typescript TypeScript
-const status = await client.maker.getSwapOrderStatus({ order_id: 'order-123' });
-// Returns: GetSwapOrderStatusResponse
-```
-
-```python Python
-from kaleidoswap_sdk import SwapOrderStatusRequest
-
-status = await client.maker.get_swap_order_status(SwapOrderStatusRequest(order_id="order-123"))
-# Returns: SwapOrderStatusResponse
-```
-</CodeGroup>
-
-#### `getOrderHistory` / `get_order_history`
-
-Get order history with optional filters.
-
-<CodeGroup>
-```typescript TypeScript
-const history = await client.maker.getOrderHistory({
-  status: 'FILLED',
-  limit: 10,
-  skip: 0
+const status = await client.maker.getSwapOrderStatus({
+  order_id: order.id,
+  access_token: order.access_token,
 });
-// Returns: GetOrderHistoryResponse
-```
 
-```python Python
-history = await client.maker.get_order_history(status="FILLED", limit=10, skip=0)
-# Returns: OrderHistoryResponse
-```
-</CodeGroup>
-
-#### `getOrderAnalytics` / `get_order_analytics`
-
-Get order statistics and analytics.
-
-<CodeGroup>
-```typescript TypeScript
-const stats = await client.maker.getOrderAnalytics();
-// Returns: GetOrderStatsResponse
-```
-
-```python Python
-stats = await client.maker.get_order_analytics()
-# Returns: OrderStatsResponse
-```
-</CodeGroup>
-
-#### `submitRateDecision` / `submit_rate_decision`
-
-Accept or reject a rate change on a pending order.
-
-<CodeGroup>
-```typescript TypeScript
-const result = await client.maker.submitRateDecision({
-  order_id: 'order-123',
-  accept_new_rate: true
+const completed = await client.maker.waitForSwapCompletion(order.id, {
+  accessToken: order.access_token,
+  timeout: 300000,
+  pollInterval: 2000,
+  onStatusUpdate: (next) => console.log(next),
 });
-// Returns: SwapOrderRateDecisionResponse
 ```
 
 ```python Python
-from kaleidoswap_sdk import RateDecisionRequest
-
-result = await client.maker.submit_rate_decision(RateDecisionRequest(
-    order_id="order-123",
-    accept_new_rate=True
-))
-# Returns: SwapOrderRateDecisionResponse
-```
-</CodeGroup>
-
-#### `waitForSwapCompletion` / `wait_for_swap_completion`
-
-Poll an order until it reaches a final state.
-
-<CodeGroup>
-```typescript TypeScript
-const completed = await client.maker.waitForSwapCompletion('order-123', {
-  timeout: 300,        // seconds
-  pollInterval: 10,    // seconds
-  onStatusUpdate: (status) => console.log(`Status: ${status}`)
-});
-// Returns: SwapOrder
-```
-
-```python Python
-completed = await client.maker.wait_for_swap_completion("order-123", options={
-    "timeout": 300,
-    "poll_interval": 10,
-    "on_status_update": lambda status: print(f"Status: {status}")
-})
-# Returns: SwapOrder
-```
-</CodeGroup>
-
----
-
-### Atomic Swap Operations
-
-These methods support the lower-level atomic swap protocol for direct node-to-node swaps.
-
-#### `initSwap` / `init_swap`
-
-Initiate an atomic swap.
-
-<CodeGroup>
-```typescript TypeScript
-const result = await client.maker.initSwap({ /* InitiateSwapRequest */ });
-```
-
-```python Python
-from kaleidoswap_sdk import SwapRequest
-
-result = await client.maker.init_swap(SwapRequest(...))
-```
-</CodeGroup>
-
-#### `executeSwap` / `execute_swap`
-
-Execute/confirm an atomic swap.
-
-<CodeGroup>
-```typescript TypeScript
-const result = await client.maker.executeSwap({ /* ConfirmSwapRequest */ });
-```
-
-```python Python
-from kaleidoswap_sdk import ConfirmSwapRequest
-
-result = await client.maker.execute_swap(ConfirmSwapRequest(...))
-```
-</CodeGroup>
-
-#### `getAtomicSwapStatus` / `get_atomic_swap_status`
-
-Get atomic swap status.
-
-<CodeGroup>
-```typescript TypeScript
-const status = await client.maker.getAtomicSwapStatus({ /* GetSwapStatusRequest */ });
-```
-
-```python Python
-from kaleidoswap_sdk import SwapStatusRequest
-
-status = await client.maker.get_atomic_swap_status(SwapStatusRequest(...))
-```
-</CodeGroup>
-
-#### `getSwapNodeInfo` / `get_swap_node_info`
-
-Get node information for swaps.
-
-<CodeGroup>
-```typescript TypeScript
-const info = await client.maker.getSwapNodeInfo();
-```
-
-```python Python
-info = await client.maker.get_swap_node_info()
-```
-</CodeGroup>
-
----
-
-### LSPS1 Operations
-
-#### `getLspInfo` / `get_lsp_info`
-
-Get LSP (Lightning Service Provider) information.
-
-<CodeGroup>
-```typescript TypeScript
-const info = await client.maker.getLspInfo();
-```
-
-```python Python
-info = await client.maker.get_lsp_info()
-```
-</CodeGroup>
-
-#### `getLspNetworkInfo` / `get_lsp_network_info`
-
-Get LSP network information.
-
-<CodeGroup>
-```typescript TypeScript
-const networkInfo = await client.maker.getLspNetworkInfo();
-```
-
-```python Python
-network_info = await client.maker.get_lsp_network_info()
-```
-</CodeGroup>
-
-#### `createLspOrder` / `create_lsp_order`
-
-Create an LSPS1 channel order.
-
-<CodeGroup>
-```typescript TypeScript
-const order = await client.maker.createLspOrder({ /* CreateLspOrderRequest */ });
-```
-
-```python Python
-from kaleidoswap_sdk import CreateOrderRequest
-
-order = await client.maker.create_lsp_order(CreateOrderRequest(...))
-```
-</CodeGroup>
-
-#### `getLspOrder` / `get_lsp_order`
-
-Get LSPS1 order status.
-
-<CodeGroup>
-```typescript TypeScript
-const order = await client.maker.getLspOrder({ order_id: 'lsp-order-123' });
-```
-
-```python Python
-from kaleidoswap_sdk import GetOrderRequest
-
-order = await client.maker.get_lsp_order(GetOrderRequest(order_id="lsp-order-123"))
-```
-</CodeGroup>
-
-#### `estimateLspFees` / `estimate_lsp_fees`
-
-Estimate fees for an LSPS1 channel order.
-
-<CodeGroup>
-```typescript TypeScript
-const fees = await client.maker.estimateLspFees({ /* CreateLspOrderRequest */ });
-```
-
-```python Python
-from kaleidoswap_sdk import CreateOrderRequest
-
-fees = await client.maker.estimate_lsp_fees(CreateOrderRequest(...))
-```
-</CodeGroup>
-
-#### `submitLspRateDecision` / `submit_lsp_rate_decision`
-
-Accept or reject a rate change on an LSP order.
-
-<CodeGroup>
-```typescript TypeScript
-const result = await client.maker.submitLspRateDecision({ /* LspRateDecisionRequest */ });
-```
-
-```python Python
-from kaleidoswap_sdk import RateDecisionRequest
-
-result = await client.maker.submit_lsp_rate_decision(RateDecisionRequest(...))
-```
-</CodeGroup>
-
-#### `retryAssetDelivery` / `retry_asset_delivery`
-
-Retry asset delivery for a failed order.
-
-<CodeGroup>
-```typescript TypeScript
-const result = await client.maker.retryAssetDelivery({ /* RetryDeliveryRequest */ });
-```
-
-```python Python
-from kaleidoswap_sdk import RetryDeliveryRequest
-
-result = await client.maker.retry_asset_delivery(RetryDeliveryRequest(...))
-```
-</CodeGroup>
-
----
-
-### WebSocket Operations
-
-#### `enableWebSocket` / `enable_websocket`
-
-Enable WebSocket for real-time quote streaming.
-
-<CodeGroup>
-```typescript TypeScript
-const ws = client.maker.enableWebSocket('wss://api.signet.kaleidoswap.com/ws/my-client-id');
-// Returns: WSClient
-```
-
-```python Python
-ws = client.maker.enable_websocket("wss://api.signet.kaleidoswap.com/ws/my-client-id")
-# Returns: WSClient
-```
-</CodeGroup>
-
-#### `streamQuotes` / `stream_quotes`
-
-Stream real-time quotes for a specific route.
-
-<CodeGroup>
-```typescript TypeScript
-const unsubscribe = await client.maker.streamQuotes(
-  'BTC',           // from_asset
-  'USDT',          // to_asset
-  100000,          // from_amount
-  'BTC_LN',        // from_layer
-  'RGB_LN',        // to_layer
-  (quote) => {
-    console.log(`Price: ${quote.price}`);
-  }
-);
-// Call unsubscribe() to stop streaming
-```
-
-```python Python
-from kaleidoswap_sdk import Layer
-
-unsubscribe = await client.maker.stream_quotes(
-    from_asset="BTC",
-    to_asset="USDT",
-    from_amount=100000,
-    from_layer=Layer.btc_ln,
-    to_layer=Layer.rgb_ln,
-    on_update=lambda quote: print(f"Price: {quote.price}")
+from kaleido_sdk import CreateSwapOrderRequest, SwapCompletionOptions, SwapOrderStatusRequest
+
+order = await client.maker.create_swap_order(
+    CreateSwapOrderRequest(
+        rfq_id=quote.rfq_id,
+        from_asset=quote.from_asset,
+        to_asset=quote.to_asset,
+        receiver_address={"address": "demo-receiver-address", "format": "BOLT11"},
+    )
 )
-# Call unsubscribe() to stop streaming
-```
-</CodeGroup>
 
-#### `streamQuotesByTicker` / `stream_quotes_by_ticker`
+status = await client.maker.get_swap_order_status(
+    SwapOrderStatusRequest(order_id=order.id)
+)
 
-Stream quotes by ticker with auto-discovered routes.
-
-<CodeGroup>
-```typescript TypeScript
-const unsubscribe = await client.maker.streamQuotesByTicker(
-  'BTC',           // fromTicker
-  'USDT',          // toTicker
-  100000,          // amount
-  (quote) => console.log(`Quote: ${quote.price}`),
-  { preferredFromLayer: 'BTC_LN', preferredToLayer: 'RGB_LN' }
-);
-```
-
-```python Python
-from kaleidoswap_sdk import Layer
-
-unsubscribe = await client.maker.stream_quotes_by_ticker(
-    from_ticker="BTC",
-    to_ticker="USDT",
-    amount=100000,
-    on_update=lambda quote: print(f"Quote: {quote.price}"),
-    preferred_from_layer=Layer.btc_ln,
-    preferred_to_layer=Layer.rgb_ln
+completed = await client.maker.wait_for_swap_completion(
+    order.id,
+    SwapCompletionOptions(timeout=300.0, poll_interval=2.0),
 )
 ```
 </CodeGroup>
 
-#### `streamQuotesForAllRoutes` / `stream_quotes_for_all_routes`
+### Atomic Swaps
 
-Stream quotes for all available routes between two assets.
+| TypeScript | Python | Notes |
+|------------|--------|-------|
+| `initSwap(body)` | `init_swap(body)` | Initialize an atomic swap |
+| `executeSwap(body)` | `execute_swap(body)` | Confirm or execute the swap |
+| `getAtomicSwapStatus(body)` | `get_atomic_swap_status(body)` | Query swap status |
+| `getSwapNodeInfo()` | `get_swap_node_info()` | Maker swap node details |
 
-<CodeGroup>
-```typescript TypeScript
-const unsubscribers = await client.maker.streamQuotesForAllRoutes(
-  'BTC', 'USDT', 100000,
-  (route, quote) => console.log(`${route}: ${quote.price}`)
-);
-// Returns: Map<string, () => void>
-```
+### LSPS1
 
-```python Python
-unsubscribers = await client.maker.stream_quotes_for_all_routes(
-    from_ticker="BTC",
-    to_ticker="USDT",
-    amount=100000,
-    on_update=lambda route, quote: print(f"{route}: {quote.price}")
-)
-# Returns: dict[str, Callable]
-```
-</CodeGroup>
+| TypeScript | Python | Notes |
+|------------|--------|-------|
+| `getLspInfo()` | `get_lsp_info()` | LSP metadata |
+| `getLspNetworkInfo()` | `get_lsp_network_info()` | LSP network info |
+| `createLspOrder(body)` | `create_lsp_order(body)` | Create LSPS1 order |
+| `getLspOrder(body)` | `get_lsp_order(body)` | Fetch LSPS1 order |
+| `estimateLspFees(body)` | `estimate_lsp_fees(body)` | Estimate order fees |
+| `submitLspRateDecision(body)` | `submit_lsp_rate_decision(body)` | Rate-decision endpoint |
 
-#### `getAvailableRoutes` / `get_available_routes`
+### WebSocket and Streaming
 
-Get available routes for a trading pair.
-
-<CodeGroup>
-```typescript TypeScript
-const routes = await client.maker.getAvailableRoutes('BTC', 'USDT');
-// Returns: Array<{ from_layer: string; to_layer: string }>
-```
-
-```python Python
-routes = await client.maker.get_available_routes("BTC", "USDT")
-# Returns: list[dict]
-```
-</CodeGroup>
-
----
-
-### Convenience Methods
-
-#### `toRaw` / `to_raw`
-
-Convert a display amount to raw (smallest unit) amount.
-
-<CodeGroup>
-```typescript TypeScript
-const raw = client.maker.toRaw(0.001, 8);  // 100000
-```
-
-```python Python
-raw = client.maker.to_raw(0.001, 8)  # 100000
-```
-</CodeGroup>
-
-#### `toDisplay` / `to_display`
-
-Convert a raw amount to display amount.
-
-<CodeGroup>
-```typescript TypeScript
-const display = client.maker.toDisplay(100000, 8);  // 0.001
-```
-
-```python Python
-display = client.maker.to_display(100000, 8)  # 0.001
-```
-</CodeGroup>
-
----
+| TypeScript | Python | Notes |
+|------------|--------|-------|
+| `enableWebSocket(wsUrl)` | `enable_websocket(ws_url, user_id=None)` | Create a `WSClient` |
+| `streamQuotes(...)` | `stream_quotes(...)` | Polling quote stream over WebSocket |
+| `streamQuotesByTicker(...)` | `stream_quotes_by_ticker(...)` | Auto-select routes |
+| `streamQuotesForAllRoutes(...)` | `stream_quotes_for_all_routes(...)` | Stream all routes |
+| `getAvailableRoutes(...)` | `get_available_routes(...)` | Route helper |
 
 ## RlnClient (`client.rln`)
 
-All RGB Lightning Node operations are accessed via `client.rln`. Requires `nodeUrl` / `node_url` to be configured.
+### Wallet and BTC
 
-### Wallet Management
+| TypeScript | Python |
+|------------|--------|
+| `getNodeInfo()` | `get_node_info()` |
+| `getNetworkInfo()` | `get_network_info()` |
+| `initWallet(body)` | `init_wallet(body)` |
+| `unlockWallet(body)` | `unlock_wallet(body)` |
+| `lockWallet()` | `lock_wallet()` |
+| `changePassword(body)` | `change_password(body)` |
+| `backup(body)` | `backup(body)` |
+| `restore(body)` | `restore(body)` |
+| `shutdown()` | `shutdown()` |
+| `getAddress()` | `get_address()` |
+| `getBtcBalance(skipSync?)` | `get_btc_balance(skip_sync=False)` |
+| `sendBtc(body)` | `send_btc(body)` |
+| `listTransactions(request?)` | `list_transactions(...)` |
+| `listUnspents()` | `list_unspents(...)` |
+| `createUtxos(body)` | `create_utxos(body)` |
+| `estimateFee(body)` | `estimate_fee(body)` |
 
-| Method (TS) | Method (Python) | Description |
-|-------------|----------------|-------------|
-| `getNodeInfo()` | `get_node_info()` | Get node information (pubkey, alias, etc.) |
-| `getNetworkInfo()` | `get_network_info()` | Get network information |
-| `initWallet(body)` | `init_wallet(body)` | Initialize a new wallet |
-| `unlockWallet(body)` | `unlock_wallet(body)` | Unlock the wallet |
-| `lockWallet()` | `lock_wallet()` | Lock the wallet |
-| `changePassword(body)` | `change_password(body)` | Change wallet password |
-| `backup(body)` | `backup(body)` | Backup node data |
-| `restore(body)` | `restore(body)` | Restore from backup |
-| `shutdown()` | `shutdown()` | Shut down the node |
+### RGB Assets
 
-### BTC Operations
+| TypeScript | Python |
+|------------|--------|
+| `listAssets(filterAssetSchemas?)` | `list_assets(filter_asset_schemas=...)` |
+| `getAssetBalance(body)` | `get_asset_balance(body)` |
+| `getAssetMetadata(body)` | `get_asset_metadata(body)` |
+| `getAssetMedia(body)` | `get_asset_media(body)` |
+| `issueAssetNIA(body)` | `issue_asset_nia(body)` |
+| `issueAssetCFA(body)` | `issue_asset_cfa(body)` |
+| `issueAssetUDA(body)` | `issue_asset_uda(body)` |
+| `sendRgb(body)` | `send_rgb(body)` |
+| `listTransfers(body)` | `list_transfers(body)` |
+| `refreshTransfers(body?)` | `refresh_transfers(body=None)` |
+| `syncRgbWallet()` | `sync_rgb_wallet()` |
+| `failTransfers(body)` | `fail_transfers(body)` |
 
-| Method (TS) | Method (Python) | Description |
-|-------------|----------------|-------------|
-| `getAddress()` | `get_address()` | Get a Bitcoin address |
-| `getBtcBalance(skipSync?)` | `get_btc_balance(skip_sync?)` | Get BTC balance |
-| `sendBtc(body)` | `send_btc(body)` | Send BTC on-chain |
-| `listTransactions(request?)` | `list_transactions(request?)` | List transactions |
-| `listUnspents()` | `list_unspents()` | List unspent outputs |
-| `createUtxos(body)` | `create_utxos(body)` | Create UTXOs |
-| `estimateFee(body)` | `estimate_fee(body)` | Estimate transaction fee |
+### Channels, Peers, Invoices, and Payments
 
-### RGB Asset Operations
+| TypeScript | Python |
+|------------|--------|
+| `listChannels()` | `list_channels()` |
+| `openChannel(body)` | `open_channel(body)` |
+| `closeChannel(body)` | `close_channel(body)` |
+| `getChannelId(body)` | `get_channel_id(body)` |
+| `listPeers()` | `list_peers()` |
+| `connectPeer(body)` | `connect_peer(body)` |
+| `disconnectPeer(body)` | `disconnect_peer(body)` |
+| `createLNInvoice(body)` | `create_ln_invoice(body)` |
+| `createRgbInvoice(body)` | `create_rgb_invoice(body)` |
+| `decodeLNInvoice(body)` | `decode_ln_invoice(body)` |
+| `decodeRgbInvoice(body)` | `decode_rgb_invoice(body)` |
+| `getInvoiceStatus(body)` | `get_invoice_status(body)` |
+| `sendPayment(body)` | `send_payment(body)` |
+| `keysend(body)` | `keysend(body)` |
+| `listPayments()` | `list_payments()` |
+| `getPayment(body)` | `get_payment(body)` |
 
-| Method (TS) | Method (Python) | Description |
-|-------------|----------------|-------------|
-| `listAssets(filter?)` | `list_assets(filter?)` | List RGB assets |
-| `getAssetBalance(body)` | `get_asset_balance(body)` | Get asset balance |
-| `getAssetMetadata(body)` | `get_asset_metadata(body)` | Get asset metadata |
-| `getAssetMedia(body)` | `get_asset_media(body)` | Get asset media |
-| `issueAssetNIA(body)` | `issue_asset_nia(body)` | Issue NIA asset |
-| `issueAssetCFA(body)` | `issue_asset_cfa(body)` | Issue CFA asset |
-| `issueAssetUDA(body)` | `issue_asset_uda(body)` | Issue UDA asset |
-| `sendAsset(body)` | `send_rgb(body)` | Send RGB asset |
-| `listTransfers(body)` | `list_transfers(body)` | List transfers |
-| `refreshTransfers(body?)` | `refresh_transfers(body?)` | Refresh transfer status |
-| `failTransfers(body)` | `fail_transfers(body)` | Fail pending transfers |
+### Swap Coordination and Utilities
 
-### Lightning Channels
+| TypeScript | Python | Notes |
+|------------|--------|-------|
+| `getTakerPubkey()` | `get_taker_pubkey()` | Returns node pubkey |
+| `whitelistSwap(body)` | `whitelist_swap(body)` | Accepts request object or raw swapstring |
+| `makerInit(body)` | `maker_init(body)` | Maker-side swap init |
+| `makerExecute(body)` | `maker_execute(body)` | Maker-side execution |
+| `listSwaps()` | `list_swaps()` | List swaps |
+| `getSwap(body)` | `get_swap(body)` | Fetch a swap |
+| `signMessage(body)` | `sign_message(body)` | Utility |
+| `sendOnionMessage(body)` | `send_onion_message(body)` | Utility |
+| `checkIndexerUrl(body)` | `check_indexer_url(body)` | Utility |
+| `checkProxyEndpoint(body)` | `check_proxy_endpoint(body)` | Utility |
+| `revokeToken(body)` | `revoke_token(body)` | Utility |
 
-| Method (TS) | Method (Python) | Description |
-|-------------|----------------|-------------|
-| `listChannels()` | `list_channels()` | List all channels |
-| `openChannel(body)` | `open_channel(body)` | Open a new channel |
-| `closeChannel(body)` | `close_channel(body)` | Close a channel |
-| `getChannelId(body)` | `get_channel_id(body)` | Get channel ID |
+## Closing the Client
 
-### Lightning Peers
+<CodeGroup>
+```typescript TypeScript
+await client.close();
+```
 
-| Method (TS) | Method (Python) | Description |
-|-------------|----------------|-------------|
-| `listPeers()` | `list_peers()` | List connected peers |
-| `connectPeer(body)` | `connect_peer(body)` | Connect to a peer |
-| `disconnectPeer(body)` | `disconnect_peer(body)` | Disconnect a peer |
-
-### Invoices and Payments
-
-| Method (TS) | Method (Python) | Description |
-|-------------|----------------|-------------|
-| `createLNInvoice(body)` | `create_ln_invoice(body)` | Create Lightning invoice |
-| `createRgbInvoice(body)` | `create_rgb_invoice(body)` | Create RGB invoice |
-| `decodeLNInvoice(body)` | `decode_ln_invoice(body)` | Decode Lightning invoice |
-| `decodeRgbInvoice(body)` | `decode_rgb_invoice(body)` | Decode RGB invoice |
-| `getInvoiceStatus(body)` | `get_invoice_status(body)` | Get invoice status |
-| `sendPayment(body)` | `send_payment(body)` | Send Lightning payment |
-| `keysend(body)` | `keysend(body)` | Send keysend payment |
-| `listPayments()` | `list_payments()` | List payments |
-| `getPayment(body)` | `get_payment(body)` | Get payment details |
-
-### Swap Operations (Node-Level)
-
-| Method (TS) | Method (Python) | Description |
-|-------------|----------------|-------------|
-| `getTakerPubkey()` | `get_taker_pubkey()` | Get taker public key |
-| `whitelistTrade(body)` | `whitelist_swap(body)` | Whitelist a trade |
-| `makerInit(body)` | `maker_init(body)` | Initialize maker swap |
-| `makerExecute(body)` | `maker_execute(body)` | Execute maker swap |
-| `listSwaps()` | `list_swaps()` | List all swaps |
-| `getSwap(body)` | `get_swap(body)` | Get swap details |
-
-### Utility Methods
-
-| Method (TS) | Method (Python) | Description |
-|-------------|----------------|-------------|
-| `signMessage(body)` | `sign_message(body)` | Sign a message |
-| `sendOnionMessage(body)` | `send_onion_message(body)` | Send an onion message |
-| `checkIndexerUrl(body)` | `check_indexer_url(body)` | Check indexer URL |
-| `checkProxyEndpoint(body)` | `check_proxy_endpoint(body)` | Check proxy endpoint |
-| `revokeToken(body)` | `revoke_token(body)` | Revoke auth token |
+```python Python
+await client.close()
+```
+</CodeGroup>

--- a/mintlify-docs/sdk/best-practices.mdx
+++ b/mintlify-docs/sdk/best-practices.mdx
@@ -11,7 +11,7 @@ Keep configuration out of source code:
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: process.env.KALEIDO_API_URL!,
@@ -22,7 +22,7 @@ const client = KaleidoClient.create({
 
 ```python Python
 import os
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 client = KaleidoClient.create(
     base_url=os.environ["KALEIDO_API_URL"],
@@ -39,7 +39,7 @@ Create one client instance and reuse it throughout your application:
 <CodeGroup>
 ```typescript TypeScript
 // lib/kaleido.ts
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 let client: KaleidoClient | null = null;
 
@@ -55,7 +55,7 @@ export function getClient(): KaleidoClient {
 
 ```python Python
 # lib/kaleido.py
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 _client = None
 
@@ -77,7 +77,7 @@ Wrap SDK calls in try/catch blocks and handle specific error types:
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoError, NetworkError, QuoteExpiredError } from 'kaleidoswap-sdk';
+import { KaleidoError, NetworkError, QuoteExpiredError } from 'kaleido-sdk';
 
 try {
   const quote = await client.maker.getQuote({ /* ... */ });
@@ -94,7 +94,7 @@ try {
 ```
 
 ```python Python
-from kaleidoswap_sdk import KaleidoError, NetworkError, QuoteExpiredError, PairQuoteRequest
+from kaleido_sdk import KaleidoError, NetworkError, QuoteExpiredError, PairQuoteRequest
 
 try:
     quote = await client.maker.get_quote(PairQuoteRequest(...))
@@ -182,7 +182,7 @@ The API works with raw (smallest unit) amounts. Convert display amounts before s
 
 <CodeGroup>
 ```typescript TypeScript
-import { toSmallestUnits } from 'kaleidoswap-sdk';
+import { toSmallestUnits } from 'kaleido-sdk';
 
 // User enters 0.001 BTC
 const userInput = 0.001;
@@ -195,7 +195,7 @@ const quote = await client.maker.getQuote({
 ```
 
 ```python Python
-from kaleidoswap_sdk import Layer, PairQuoteRequest, SwapLegInput, to_smallest_units
+from kaleido_sdk import Layer, PairQuoteRequest, SwapLegInput, to_smallest_units
 
 # User enters 0.001 BTC
 user_input = 0.001
@@ -214,7 +214,7 @@ When working with multiple assets, use `PrecisionHandler` to avoid precision err
 
 <CodeGroup>
 ```typescript TypeScript
-import { createPrecisionHandler } from 'kaleidoswap-sdk';
+import { createPrecisionHandler } from 'kaleido-sdk';
 
 const handler = createPrecisionHandler(mappedAssets);
 
@@ -224,7 +224,7 @@ const display = handler.toDisplayAmount(rawFromApi, assetId);
 ```
 
 ```python Python
-from kaleidoswap_sdk import create_precision_handler
+from kaleido_sdk import create_precision_handler
 
 handler = create_precision_handler(mapped_assets)
 raw = handler.to_raw_amount(user_input, asset_id)

--- a/mintlify-docs/sdk/changelog.mdx
+++ b/mintlify-docs/sdk/changelog.mdx
@@ -4,7 +4,7 @@ description: SDK and API version history for KaleidoSwap
 ---
 
 <Note>
-  This changelog covers the KaleidoSwap SDK (`kaleidoswap-sdk`) and the Maker API (`/api/v1`). For desktop app releases, see the [GitHub releases page](https://github.com/kaleidoswap/desktop-app/releases).
+  This changelog covers the KaleidoSwap SDK (`kaleido-sdk`) and the Maker API (`/api/v1`). For desktop app releases, see the [GitHub releases page](https://github.com/kaleidoswap/desktop-app/releases).
 </Note>
 
 ## SDK v0.5.x — Current

--- a/mintlify-docs/sdk/error-handling.mdx
+++ b/mintlify-docs/sdk/error-handling.mdx
@@ -37,7 +37,7 @@ All SDK errors extend `KaleidoError` with these properties:
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoError } from 'kaleidoswap-sdk';
+import { KaleidoError } from 'kaleido-sdk';
 
 try {
   await client.maker.listPairs();
@@ -52,7 +52,7 @@ try {
 ```
 
 ```python Python
-from kaleidoswap_sdk import KaleidoError
+from kaleido_sdk import KaleidoError
 
 try:
     await client.maker.list_pairs()
@@ -72,12 +72,12 @@ Raised for HTTP errors (status 400-599).
 
 <CodeGroup>
 ```typescript TypeScript
-import { APIError } from 'kaleidoswap-sdk';
+import { APIError } from 'kaleido-sdk';
 // Properties: code='API_ERROR', statusCode, message, details
 ```
 
 ```python Python
-from kaleidoswap_sdk import APIError
+from kaleido_sdk import APIError
 # Properties: code='API_ERROR', status_code, response_body
 ```
 </CodeGroup>
@@ -88,7 +88,7 @@ Raised when rate limit is exceeded (HTTP 429). Extends `APIError`.
 
 <CodeGroup>
 ```typescript TypeScript
-import { RateLimitError } from 'kaleidoswap-sdk';
+import { RateLimitError } from 'kaleido-sdk';
 // Additional property: retryAfter?: number (seconds)
 
 try { /* ... */ } catch (error) {
@@ -99,7 +99,7 @@ try { /* ... */ } catch (error) {
 ```
 
 ```python Python
-from kaleidoswap_sdk import RateLimitError
+from kaleido_sdk import RateLimitError
 # Additional property: retry_after: int | None
 
 try:
@@ -143,7 +143,7 @@ Raised for swap operation failures.
 
 <CodeGroup>
 ```typescript TypeScript
-import { SwapError } from 'kaleidoswap-sdk';
+import { SwapError } from 'kaleido-sdk';
 // Additional property: swapId?: string
 
 try { /* ... */ } catch (error) {
@@ -154,7 +154,7 @@ try { /* ... */ } catch (error) {
 ```
 
 ```python Python
-from kaleidoswap_sdk import SwapError
+from kaleido_sdk import SwapError
 # Additional property: swap_id: str | None
 ```
 </CodeGroup>
@@ -165,7 +165,7 @@ Raised when an RLN node operation is attempted without a configured `nodeUrl`.
 
 <CodeGroup>
 ```typescript TypeScript
-import { NodeNotConfiguredError } from 'kaleidoswap-sdk';
+import { NodeNotConfiguredError } from 'kaleido-sdk';
 
 try {
   await client.rln.getNodeInfo();
@@ -177,7 +177,7 @@ try {
 ```
 
 ```python Python
-from kaleidoswap_sdk import NodeNotConfiguredError
+from kaleido_sdk import NodeNotConfiguredError
 
 try:
     await client.rln.get_node_info()
@@ -196,7 +196,7 @@ Raised when a balance is insufficient for the requested operation.
 
 <CodeGroup>
 ```typescript TypeScript
-import { InsufficientBalanceError } from 'kaleidoswap-sdk';
+import { InsufficientBalanceError } from 'kaleido-sdk';
 // Properties: requiredAmount: bigint, availableAmount: bigint, asset?: string
 
 try { /* ... */ } catch (error) {
@@ -207,7 +207,7 @@ try { /* ... */ } catch (error) {
 ```
 
 ```python Python
-from kaleidoswap_sdk import InsufficientBalanceError
+from kaleido_sdk import InsufficientBalanceError
 # Properties: required_amount, available_amount, asset
 
 try:
@@ -232,7 +232,7 @@ import {
   NodeNotConfiguredError,
   InsufficientBalanceError,
   RateLimitError,
-} from 'kaleidoswap-sdk';
+} from 'kaleido-sdk';
 
 try {
   const quote = await client.maker.getQuote({ /* ... */ });
@@ -264,7 +264,7 @@ try {
 ```
 
 ```python Python
-from kaleidoswap_sdk import (
+from kaleido_sdk import (
     KaleidoError,
     APIError,
     NetworkError,

--- a/mintlify-docs/sdk/examples.mdx
+++ b/mintlify-docs/sdk/examples.mdx
@@ -1,689 +1,320 @@
 ---
 title: 'Examples'
-description: 'Real-world code examples for common use cases'
+description: 'Common integration examples for the Kaleido SDK'
 ---
 
-## Market Data Exploration
-
-Fetch and display available assets and trading pairs.
+## Market Data
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: 'https://api.regtest.kaleidoswap.com',
 });
 
-// Fetch assets and pairs
 const [assets, pairs] = await Promise.all([
   client.maker.listAssets(),
   client.maker.listPairs(),
 ]);
 
 console.log(`Assets: ${assets.assets.length}`);
-console.log(`Trading Pairs: ${pairs.pairs.length}`);
+console.log(`Pairs: ${pairs.pairs.length}`);
 
-// Display each pair
-for (const pair of pairs.pairs) {
-  console.log(`${pair.base_asset_ticker}/${pair.quote_asset_ticker}`);
-  for (const route of pair.routes ?? []) {
-    console.log(`  Route: ${route.from_layer} -> ${route.to_layer}`);
-    console.log(`  Min: ${route.min_from_amount} / Max: ${route.max_from_amount}`);
-  }
+for (const pair of pairs.pairs.slice(0, 5)) {
+  console.log(`${pair.base.ticker}/${pair.quote.ticker}`);
 }
 ```
 
 ```python Python
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 client = KaleidoClient.create(
     base_url="https://api.regtest.kaleidoswap.com"
 )
 
-# Fetch assets and pairs
 assets = await client.maker.list_assets()
 pairs = await client.maker.list_pairs()
 
 print(f"Assets: {len(assets.assets)}")
-print(f"Trading Pairs: {len(pairs.pairs)}")
+print(f"Pairs: {len(pairs.pairs)}")
 
-# Display each pair
-for pair in pairs.pairs:
-    print(f"{pair.base_asset_ticker}/{pair.quote_asset_ticker}")
-    for route in pair.routes or []:
-        print(f"  Route: {route.from_layer} -> {route.to_layer}")
-        print(f"  Min: {route.min_from_amount} / Max: {route.max_from_amount}")
+for pair in pairs.pairs[:5]:
+    print(f"{pair.base.ticker}/{pair.quote.ticker}")
 ```
 </CodeGroup>
 
-## Getting a Quote
-
-Request a price quote before creating a swap order.
+## Request a Quote
 
 <CodeGroup>
 ```typescript TypeScript
+import { KaleidoClient, Layer } from 'kaleido-sdk';
+
+const client = KaleidoClient.create();
+
 const quote = await client.maker.getQuote({
-  from_asset: { asset_id: 'BTC', layer: 'BTC_LN', amount: 100000 },
-  to_asset: { asset_id: 'USDT', layer: 'RGB_LN' }
+  from_asset: { asset_id: 'BTC', layer: Layer.BTC_LN, amount: 100000 },
+  to_asset: { asset_id: 'USDT', layer: Layer.RGB_LN },
 });
 
 console.log(`RFQ ID: ${quote.rfq_id}`);
-console.log(`From: ${quote.from_amount} sats`);
-console.log(`To: ${quote.to_amount} USDT`);
 console.log(`Price: ${quote.price}`);
-console.log(`Expires: ${new Date(quote.expires_at * 1000).toISOString()}`);
+console.log(`From: ${quote.from_asset.amount} ${quote.from_asset.ticker}`);
+console.log(`To: ${quote.to_asset.amount} ${quote.to_asset.ticker}`);
 ```
 
 ```python Python
-quote = await client.maker.get_quote(PairQuoteRequest(
-    from_asset=SwapLegInput(asset_id="BTC", layer=Layer.btc_ln, amount=100000),
-    to_asset=SwapLegInput(asset_id="USDT", layer=Layer.rgb_ln)
-))
+from kaleido_sdk import KaleidoClient, Layer, PairQuoteRequest, SwapLegInput
+
+client = KaleidoClient.create()
+
+quote = await client.maker.get_quote(
+    PairQuoteRequest(
+        from_asset=SwapLegInput(asset_id="BTC", layer=Layer.BTC_LN, amount=100000),
+        to_asset=SwapLegInput(asset_id="USDT", layer=Layer.RGB_LN),
+    )
+)
 
 print(f"RFQ ID: {quote.rfq_id}")
-print(f"From: {quote.from_amount} sats")
-print(f"To: {quote.to_amount} USDT")
 print(f"Price: {quote.price}")
-print(f"Expires: {quote.expires_at}")
+print(f"From: {quote.from_asset.amount} {quote.from_asset.ticker}")
+print(f"To: {quote.to_asset.amount} {quote.to_asset.ticker}")
 ```
 </CodeGroup>
 
-## Complete Order-Based Swap
+## Create a Swap Order
 
-The full swap flow: get a quote, create an order, and track it to completion.
+This mirrors the order-based flow that is implemented in the SDK today: request a quote, create an order, then poll for status.
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient, KaleidoError } from 'kaleidoswap-sdk';
+import { KaleidoClient, Layer, ReceiverAddressFormat } from 'kaleido-sdk';
 
-const client = KaleidoClient.create({
-  baseUrl: 'https://api.regtest.kaleidoswap.com',
+const client = KaleidoClient.create();
+
+const quote = await client.maker.getQuote({
+  from_asset: { asset_id: 'BTC', layer: Layer.BTC_LN, amount: 100000 },
+  to_asset: { asset_id: 'USDT', layer: Layer.RGB_LN },
 });
 
-async function executeSwap() {
-  // Step 1: Get a quote
-  const quote = await client.maker.getQuote({
-    from_asset: { asset_id: 'BTC', layer: 'BTC_LN', amount: 100000 },
-    to_asset: { asset_id: 'USDT', layer: 'RGB_LN' }
-  });
+const order = await client.maker.createSwapOrder({
+  rfq_id: quote.rfq_id,
+  from_asset: quote.from_asset,
+  to_asset: quote.to_asset,
+  receiver_address: {
+    address: 'demo-receiver-address',
+    format: ReceiverAddressFormat.BOLT11,
+  },
+});
 
-  console.log(`Quote received: ${quote.from_amount} -> ${quote.to_amount}`);
-  console.log(`Price: ${quote.price}`);
+const finalOrder = await client.maker.waitForSwapCompletion(order.id, {
+  accessToken: order.access_token,
+  timeout: 300000,
+  pollInterval: 2000,
+  onStatusUpdate: (status) => console.log(`Status: ${status}`),
+});
 
-  // Step 2: Create the swap order (use the quote's from_asset/to_asset — they are SwapLeg with amounts)
-  const order = await client.maker.createSwapOrder({
-    rfq_id: quote.rfq_id,
-    from_asset: quote.from_asset,
-    to_asset: quote.to_asset,
-    receiver_address: 'lnbc1...',  // your destination address/invoice
-  });
-
-  console.log(`Order created: ${order.order_id}`);
-  console.log(`Deposit address: ${order.deposit_address}`);
-  console.log(`Pay this invoice/address to proceed.`);
-
-  // Step 3: Wait for the user to pay, then track to completion
-  const completed = await client.maker.waitForSwapCompletion(order.order_id, {
-    timeout: 600,
-    pollInterval: 10,
-    onStatusUpdate: (status) => console.log(`Status: ${status}`)
-  });
-
-  console.log(`Swap completed! Final status: ${completed.status}`);
-}
-
-executeSwap().catch(console.error);
+console.log(finalOrder.status);
 ```
 
 ```python Python
-from kaleidoswap_sdk import (
+from kaleido_sdk import (
     CreateSwapOrderRequest,
     KaleidoClient,
-    KaleidoError,
     Layer,
     PairQuoteRequest,
+    ReceiverAddressFormat,
+    SwapCompletionOptions,
     SwapLegInput,
 )
-client = KaleidoClient.create(
-    base_url="https://api.regtest.kaleidoswap.com"
+
+client = KaleidoClient.create()
+
+quote = await client.maker.get_quote(
+    PairQuoteRequest(
+        from_asset=SwapLegInput(asset_id="BTC", layer=Layer.BTC_LN, amount=100000),
+        to_asset=SwapLegInput(asset_id="USDT", layer=Layer.RGB_LN),
+    )
 )
 
-def execute_swap():
-    # Step 1: Get a quote
-    quote = await client.maker.get_quote(PairQuoteRequest(
-        from_asset=SwapLegInput(asset_id="BTC", layer=Layer.btc_ln, amount=100000),
-        to_asset=SwapLegInput(asset_id="USDT", layer=Layer.rgb_ln)
-    ))
-
-    print(f"Quote received: {quote.from_amount} -> {quote.to_amount}")
-    print(f"Price: {quote.price}")
-
-    # Step 2: Create the swap order (use the quote's from_asset/to_asset — they are SwapLeg with amounts)
-    order = await client.maker.create_swap_order(CreateSwapOrderRequest(
+order = await client.maker.create_swap_order(
+    CreateSwapOrderRequest(
         rfq_id=quote.rfq_id,
         from_asset=quote.from_asset,
         to_asset=quote.to_asset,
-        receiver_address="lnbc1...",  # your destination address/invoice
-    ))
+        receiver_address={
+            "address": "demo-receiver-address",
+            "format": ReceiverAddressFormat.BOLT11,
+        },
+    )
+)
 
-    print(f"Order created: {order.order_id}")
-    print(f"Deposit address: {order.deposit_address}")
-    print("Pay this invoice/address to proceed.")
+final_order = await client.maker.wait_for_swap_completion(
+    order.id,
+    SwapCompletionOptions(
+        timeout=300.0,
+        poll_interval=2.0,
+        on_status_update=lambda status: print(f"Status: {status}"),
+    ),
+)
 
-    # Step 3: Wait for the user to pay, then track to completion
-    completed = await client.maker.wait_for_swap_completion(order.order_id, options={
-        "timeout": 600,
-        "poll_interval": 10,
-        "on_status_update": lambda status: print(f"Status: {status}")
-    })
-
-    print(f"Swap completed! Final status: {completed.status}")
-
-execute_swap()
+print(final_order.status)
 ```
 </CodeGroup>
 
-## Atomic Swap (Desktop / Node Integration)
-
-The full atomic swap flow used by the desktop app. Requires a running RGB Lightning Node.
-
-<Note>
-  Atomic swaps settle trustlessly via HTLC on the Lightning Network. Both sides lock assets simultaneously — either the full exchange completes or funds are returned. See [Swap Protocol](/api-reference/swap-protocol) for a full explanation.
-</Note>
+## Atomic Swap Initialization
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient, Layer } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: 'https://api.signet.kaleidoswap.com',
-  nodeUrl: 'http://localhost:3001',  // your RLN node
 });
 
-async function executeAtomicSwap() {
-  // Step 1: Get your node's taker pubkey
-  const takerPubkey = await client.rln.getTakerPubkey();
+const quote = await client.maker.getQuote({
+  from_asset: { asset_id: 'BTC', layer: Layer.BTC_LN, amount: 4100000 },
+  to_asset: { asset_id: 'USDT', layer: Layer.RGB_LN },
+});
 
-  // Step 2: Enable WebSocket and get an rfq_id
-  client.maker.enableWebSocket('wss://api.signet.kaleidoswap.com/ws/my-client');
+const swap = await client.maker.initSwap({
+  rfq_id: quote.rfq_id,
+  from_asset: quote.from_asset.asset_id,
+  from_amount: quote.from_asset.amount,
+  to_asset: quote.to_asset.asset_id,
+  to_amount: quote.to_asset.amount,
+});
 
-  const rfqId = await new Promise<string>((resolve) => {
-    client.maker.streamQuotesByTicker('BTC', 'USDT', 100000, (quote) => {
-      resolve(quote.rfq_id);
-    });
-  });
-
-  // Step 3: Initiate the swap — locks the price
-  const { swapstring, payment_hash } = await client.maker.initSwap({
-    rfq_id: rfqId,
-    from_asset: 'btc',
-    from_amount: 100000,       // millisats
-    to_asset: 'rgb:...',       // USDT asset ID
-    to_amount: 9500,
-  });
-
-  // Step 4: Whitelist the swap on your RGB Lightning Node
-  await client.rln.whitelistTrade({ swapstring });
-
-  // Step 5: Execute — both sides lock and settle atomically
-  await client.maker.executeSwap({
-    swapstring,
-    taker_pubkey: takerPubkey.pubkey,
-    payment_hash,
-  });
-
-  console.log('Atomic swap complete!');
-}
-
-executeAtomicSwap().catch(console.error);
+console.log(swap.payment_hash);
+console.log(swap.swapstring);
 ```
 
 ```python Python
-from kaleidoswap_sdk import (
-    ConfirmSwapRequest,
-    KaleidoClient,
-    Layer,
-    PairQuoteRequest,
-    SwapLegInput,
-    SwapRequest,
-)
-from kaleidoswap_sdk.rln import TakerRequest
+from kaleido_sdk import KaleidoClient, Layer, PairQuoteRequest, SwapLegInput, SwapRequest
 
 client = KaleidoClient.create(
-    base_url="https://api.signet.kaleidoswap.com",
-    node_url="http://localhost:3001",  # your RLN node
+    base_url="https://api.signet.kaleidoswap.com"
 )
 
-def execute_atomic_swap():
-    # Step 1: Get your node's taker pubkey
-    taker_info = await client.rln.get_taker_pubkey()
+quote = await client.maker.get_quote(
+    PairQuoteRequest(
+        from_asset=SwapLegInput(asset_id="BTC", layer=Layer.BTC_LN, amount=4_100_000),
+        to_asset=SwapLegInput(asset_id="USDT", layer=Layer.RGB_LN),
+    )
+)
 
-    # Step 2: Enable WebSocket and get an rfq_id via a quote
-    client.maker.enable_websocket("wss://api.signet.kaleidoswap.com/ws/my-client")
+swap = await client.maker.init_swap(
+    SwapRequest(
+        rfq_id=quote.rfq_id,
+        from_asset=quote.from_asset.asset_id,
+        from_amount=quote.from_asset.amount,
+        to_asset=quote.to_asset.asset_id,
+        to_amount=quote.to_asset.amount,
+    )
+)
 
-    quote = await client.maker.get_quote(PairQuoteRequest(
-        from_asset=SwapLegInput(asset_id="BTC", layer=Layer.btc_ln, amount=100000),
-        to_asset=SwapLegInput(asset_id="USDT", layer=Layer.rgb_ln)
-    ))
-    rfq_id = quote.rfq_id
-
-    # Step 3: Initiate the swap — locks the price
-    swap = await client.maker.init_swap(SwapRequest(
-        rfq_id=rfq_id,
-        from_asset="btc",
-        from_amount=100000,       # millisats
-        to_asset="rgb:...",       # USDT asset ID
-        to_amount=quote.to_amount,
-    ))
-
-    # Step 4: Whitelist the swap on your RGB Lightning Node
-    await client.rln.whitelist_swap(TakerRequest(swapstring=swap.swapstring))
-
-    # Step 5: Execute — both sides lock and settle atomically
-    await client.maker.execute_swap(ConfirmSwapRequest(
-        swapstring=swap.swapstring,
-        taker_pubkey=taker_info.pubkey,
-        payment_hash=swap.payment_hash,
-    ))
-
-    print("Atomic swap complete!")
-
-execute_atomic_swap()
+print(swap.payment_hash)
+print(swap.swapstring)
 ```
 </CodeGroup>
 
-## WebSocket Quote Streaming
-
-Stream real-time quotes using WebSocket.
-
-### Using `streamQuotesByTicker`
-
-The simplest way to get live quotes:
+## WebSocket Streaming
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
-  baseUrl: 'https://api.regtest.kaleidoswap.com',
+  baseUrl: 'https://api.signet.kaleidoswap.com',
 });
 
-// Enable WebSocket
-client.maker.enableWebSocket('wss://api.regtest.kaleidoswap.com/ws/my-client');
+client.maker.enableWebSocket('wss://api.signet.kaleidoswap.com/ws/my-client-id');
 
-// Stream quotes
-const unsubscribe = await client.maker.streamQuotesByTicker(
+const stop = await client.maker.streamQuotesByTicker(
   'BTC',
   'USDT',
   100000,
-  (quote) => {
-    console.log(`Price: ${quote.price}`);
-    console.log(`From: ${quote.from_amount} -> To: ${quote.to_amount}`);
-    console.log(`Fee: ${quote.fee.final_fee}`);
-    console.log(`RFQ ID: ${quote.rfq_id}`);
-  },
-  { preferredFromLayer: 'BTC_LN', preferredToLayer: 'RGB_LN' }
+  (quote) => console.log(quote.price),
+  { pollInterval: 2000 }
 );
 
-// Stop streaming after 60 seconds
-setTimeout(() => unsubscribe(), 60000);
+setTimeout(() => stop(), 10000);
 ```
 
 ```python Python
-from kaleidoswap_sdk import KaleidoClient, Layer
+from kaleido_sdk import KaleidoClient
 
 client = KaleidoClient.create(
-    base_url="https://api.regtest.kaleidoswap.com"
+    base_url="https://api.signet.kaleidoswap.com"
 )
 
-# Enable WebSocket
-client.maker.enable_websocket("wss://api.regtest.kaleidoswap.com/ws/my-client")
+client.maker.enable_websocket("wss://api.signet.kaleidoswap.com/ws/my-client-id")
 
-# Stream quotes
-unsubscribe = await client.maker.stream_quotes_by_ticker(
-    from_ticker="BTC",
-    to_ticker="USDT",
-    amount=100000,
-    on_update=lambda quote: print(
-        f"Price: {quote.price}, "
-        f"From: {quote.from_amount} -> To: {quote.to_amount}"
-    ),
-    preferred_from_layer=Layer.btc_ln,
-    preferred_to_layer=Layer.rgb_ln
+stop = await client.maker.stream_quotes_by_ticker(
+    "BTC",
+    "USDT",
+    100000,
+    lambda quote: print(quote.price),
+    poll_interval=2.0,
 )
 
-# Call unsubscribe() when done
+stop()
 ```
 </CodeGroup>
 
-### Using WSClient Directly
-
-For more control, use the WSClient event-based API:
+## RLN Operations
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
-  baseUrl: 'https://api.regtest.kaleidoswap.com',
-});
-
-const ws = client.maker.enableWebSocket('wss://api.regtest.kaleidoswap.com/ws/my-client');
-
-ws.on('connected', () => {
-  console.log('WebSocket connected');
-
-  // Request a quote
-  ws.requestQuote({
-    from_asset: 'BTC',
-    to_asset: 'USDT',
-    from_amount: 100000,
-    from_layer: 'BTC_LN',
-    to_layer: 'RGB_LN'
-  });
-});
-
-ws.on('quoteResponse', (quote) => {
-  console.log(`Price: ${quote.price}`);
-  console.log(`RFQ ID: ${quote.rfq_id}`);
-});
-
-ws.on('error', (error) => {
-  console.error('WebSocket error:', error.message);
-});
-
-ws.on('disconnected', () => {
-  console.log('WebSocket disconnected');
-});
-
-await ws.connect();
-```
-
-```python Python
-from kaleidoswap_sdk import KaleidoClient
-
-client = KaleidoClient.create(
-    base_url="https://api.regtest.kaleidoswap.com"
-)
-
-ws = client.maker.enable_websocket("wss://api.regtest.kaleidoswap.com/ws/my-client")
-
-def on_connected():
-    print("WebSocket connected")
-    ws.request_quote({
-        "from_asset": "BTC",
-        "to_asset": "USDT",
-        "from_amount": 100000,
-        "from_layer": "BTC_LN",
-        "to_layer": "RGB_LN"
-    })
-
-def on_quote(quote):
-    print(f"Price: {quote['price']}")
-    print(f"RFQ ID: {quote['rfq_id']}")
-
-ws.on("connected", on_connected)
-ws.on("quote_response", on_quote)
-ws.on("error", lambda err: print(f"Error: {err}"))
-
-await ws.connect()
-```
-</CodeGroup>
-
-## Order Management
-
-Track and manage swap orders.
-
-<CodeGroup>
-```typescript TypeScript
-// Check order status
-const status = await client.maker.getSwapOrderStatus({ order_id: 'order-123' });
-console.log(`Status: ${status.status}`);
-console.log(`Payment: ${status.payment_status}`);
-
-// Get order history
-const history = await client.maker.getOrderHistory({ limit: 20 });
-for (const order of history.orders) {
-  console.log(`${order.order_id}: ${order.status}`);
-}
-
-// Get analytics
-const stats = await client.maker.getOrderAnalytics();
-console.log(`Total orders: ${stats.total_orders}`);
-```
-
-```python Python
-from kaleidoswap_sdk import SwapOrderStatusRequest
-
-# Check order status
-status = await client.maker.get_swap_order_status(SwapOrderStatusRequest(order_id="order-123"))
-print(f"Status: {status.status}")
-print(f"Payment: {status.payment_status}")
-
-# Get order history
-history = await client.maker.get_order_history(limit=20)
-for order in history.orders:
-    print(f"{order.order_id}: {order.status}")
-
-# Get analytics
-stats = await client.maker.get_order_analytics()
-print(f"Total orders: {stats.total_orders}")
-```
-</CodeGroup>
-
-## Rate Decision Handling
-
-Handle rate changes on pending orders.
-
-<CodeGroup>
-```typescript TypeScript
-const status = await client.maker.getSwapOrderStatus({ order_id: 'order-123' });
-
-if (status.status === 'PENDING_RATE_DECISION') {
-  // Accept the new rate
-  const result = await client.maker.submitRateDecision({
-    order_id: 'order-123',
-    accept_new_rate: true
-  });
-  console.log('Rate accepted, swap continues');
-
-  // Or reject and get a refund:
-  // await client.maker.submitRateDecision({
-  //   order_id: 'order-123',
-  //   accept_new_rate: false
-  // });
-}
-```
-
-```python Python
-from kaleidoswap_sdk import RateDecisionRequest, SwapOrderStatusRequest
-
-status = await client.maker.get_swap_order_status(SwapOrderStatusRequest(order_id="order-123"))
-
-if status.status == "PENDING_RATE_DECISION":
-    # Accept the new rate
-    result = await client.maker.submit_rate_decision(RateDecisionRequest(
-        order_id="order-123",
-        accept_new_rate=True
-    ))
-    print("Rate accepted, swap continues")
-
-    # Or reject and get a refund:
-    # client.maker.submit_rate_decision(RateDecisionRequest(
-    #     order_id="order-123",
-    #     accept_new_rate=False
-    # ))
-```
-</CodeGroup>
-
-## RLN Node Operations
-
-Manage your RGB Lightning Node.
-
-<CodeGroup>
-```typescript TypeScript
-const client = KaleidoClient.create({
-  baseUrl: 'https://api.regtest.kaleidoswap.com',
   nodeUrl: 'http://localhost:3001',
 });
 
-// Get node info
-const nodeInfo = await client.rln.getNodeInfo();
-console.log(`Pubkey: ${nodeInfo.pubkey}`);
+if (client.hasNode()) {
+  const nodeInfo = await client.rln.getNodeInfo();
+  const balance = await client.rln.getBtcBalance();
 
-// Get balances
-const btcBalance = await client.rln.getBtcBalance();
-console.log(`On-chain: ${btcBalance.vanilla.spendable} sats`);
-
-// List RGB assets
-const rgbAssets = await client.rln.listAssets();
-console.log(`RGB assets: ${rgbAssets.nia.length} NIA assets`);
-
-// List channels
-const channels = await client.rln.listChannels();
-console.log(`Channels: ${channels.channels.length}`);
-
-// Create a Lightning invoice
-const invoice = await client.rln.createLNInvoice({
-  amt_msat: 100000,
-  expiry_sec: 3600,
-  description: 'Payment for service'
-});
-console.log(`Invoice: ${invoice.invoice}`);
-```
-
-```python Python
-from kaleidoswap_sdk import KaleidoClient
-from kaleidoswap_sdk.rln import LNInvoiceRequest
-
-client = KaleidoClient.create(
-    base_url="https://api.regtest.kaleidoswap.com",
-    node_url="http://localhost:3001"
-)
-
-# Get node info
-node_info = await client.rln.get_node_info()
-print(f"Pubkey: {node_info.pubkey}")
-
-# Get balances
-btc_balance = await client.rln.get_btc_balance()
-print(f"On-chain: {btc_balance.vanilla.spendable} sats")
-
-# List RGB assets
-rgb_assets = await client.rln.list_assets()
-print(f"RGB assets: {len(rgb_assets.nia)} NIA assets")
-
-# List channels
-channels = await client.rln.list_channels()
-print(f"Channels: {len(channels.channels)}")
-
-# Create a Lightning invoice
-invoice = await client.rln.create_ln_invoice(LNInvoiceRequest(
-    amt_msat=100000,
-    expiry_sec=3600,
-    description="Payment for service"
-))
-print(f"Invoice: {invoice.invoice}")
-```
-</CodeGroup>
-
-## Amount Conversion
-
-Use precision utilities for safe amount conversion.
-
-<CodeGroup>
-```typescript TypeScript
-import { toSmallestUnits, toDisplayUnits, createPrecisionHandler } from 'kaleidoswap-sdk';
-
-// Simple conversion
-const sats = toSmallestUnits(0.001, 8);     // 100000
-const btc = toDisplayUnits(100000, 8);       // 0.001
-
-// Using PrecisionHandler with asset metadata
-const pairs = await client.maker.listPairs();
-// ... create mapped assets from pairs
-// const handler = createPrecisionHandler(mappedAssets);
-// const raw = handler.toRawAmount(0.5, 'BTC_ASSET_ID');
-// const display = handler.toDisplayAmount(50000000, 'BTC_ASSET_ID');
-```
-
-```python Python
-from kaleidoswap_sdk import to_smallest_units, to_display_units, create_precision_handler
-
-# Simple conversion
-sats = to_smallest_units(0.001, 8)     # 100000
-btc = to_display_units(100000, 8)       # 0.001
-
-# Using PrecisionHandler with asset metadata
-pairs = await client.maker.list_pairs()
-# ... create mapped assets from pairs
-# handler = create_precision_handler(mapped_assets)
-# raw = handler.to_raw_amount(0.5, "BTC_ASSET_ID")
-# display = handler.to_display_amount(50000000, "BTC_ASSET_ID")
-```
-</CodeGroup>
-
-## Error Handling
-
-Handle specific error types for robust applications.
-
-<CodeGroup>
-```typescript TypeScript
-import {
-  KaleidoClient,
-  KaleidoError,
-  NetworkError,
-  ValidationError,
-  QuoteExpiredError,
-  NodeNotConfiguredError,
-} from 'kaleidoswap-sdk';
-
-try {
-  const quote = await client.maker.getQuote({ /* ... */ });
-  const order = await client.maker.createSwapOrder({ /* ... */ });
-} catch (error) {
-  if (error instanceof QuoteExpiredError) {
-    console.log('Quote expired, fetching a new one...');
-  } else if (error instanceof ValidationError) {
-    console.log(`Invalid input: ${error.message}`);
-  } else if (error instanceof NodeNotConfiguredError) {
-    console.log('Node not configured for this operation');
-  } else if (error instanceof NetworkError) {
-    console.log(`Network issue: ${error.message}`);
-    if (error.isRetryable()) {
-      console.log('Retrying...');
-    }
-  } else if (error instanceof KaleidoError) {
-    console.log(`SDK error [${error.code}]: ${error.message}`);
-  }
+  console.log(nodeInfo.pubkey);
+  console.log(balance);
 }
 ```
 
 ```python Python
-from kaleidoswap_sdk import (
-    KaleidoClient,
-    KaleidoError,
-    NetworkError,
-    ValidationError,
-    QuoteExpiredError,
-    NodeNotConfiguredError,
+from kaleido_sdk import KaleidoClient
+
+client = KaleidoClient.create(
+    node_url="http://localhost:3001"
 )
 
-try:
-    quote = await client.maker.get_quote(PairQuoteRequest(...))
-    order = await client.maker.create_swap_order(CreateSwapOrderRequest(...))
-except QuoteExpiredError:
-    print("Quote expired, fetching a new one...")
-except ValidationError as e:
-    print(f"Invalid input: {e}")
-except NodeNotConfiguredError:
-    print("Node not configured for this operation")
-except NetworkError as e:
-    print(f"Network issue: {e}")
-    if e.is_retryable():
-        print("Retrying...")
-except KaleidoError as e:
-    print(f"SDK error [{e.code}]: {e}")
+if client.has_node():
+    node_info = await client.rln.get_node_info()
+    balance = await client.rln.get_btc_balance()
+
+    print(node_info.pubkey)
+    print(balance)
+```
+</CodeGroup>
+
+## Utilities
+
+<CodeGroup>
+```typescript TypeScript
+import { toSmallestUnits, toDisplayUnits, getSdkName, getVersion } from 'kaleido-sdk';
+
+console.log(toSmallestUnits(0.001, 8)); // 100000
+console.log(toDisplayUnits(100000, 8)); // 0.001
+console.log(getSdkName());              // "kaleido-sdk"
+console.log(getVersion());              // "0.1.0"
+```
+
+```python Python
+from kaleido_sdk import to_smallest_units, to_display_units, get_sdk_name, get_version
+
+print(to_smallest_units(0.001, 8))  # 100000
+print(to_display_units(100000, 8))  # 0.001
+print(get_sdk_name())               # "kaleido-sdk"
+print(get_version())                # "0.1.0"
 ```
 </CodeGroup>

--- a/mintlify-docs/sdk/getting-started.mdx
+++ b/mintlify-docs/sdk/getting-started.mdx
@@ -1,39 +1,34 @@
 ---
 title: 'Getting Started'
-description: 'Install and configure the KaleidoSwap SDK for TypeScript or Python'
+description: 'Install and configure the Kaleido SDK for TypeScript or Python'
 ---
 
 ## Version Compatibility
 
-**SDK v0.5.x** is compatible with the **latest versions** of both Maker API and RLN API.
+The current SDK implementation in `kaleidosdk` is `v0.1.0` for both TypeScript and Python.
 
-The SDK automatically supports the most recent API releases. Simply keep your SDK updated to access the latest features and improvements.
+Both SDKs are generated from the same Maker API and RGB Lightning Node specs, then wrapped with handwritten clients for:
 
-| SDK Version | Maker API | RLN API | Supported Environments |
-|-------------|-----------|---------|------------------------|
-| **0.5.x** | Latest | Latest | Regtest, Signet (mutinynet), Testnet4 (soon) |
-
-<Note>
-  Mainnet support is coming soon. Pin your SDK version in `package.json` / `requirements.txt` to avoid unexpected breaking changes between minor releases.
-</Note>
+- `client.maker` for Kaleidoswap market, swap, and LSPS1 endpoints
+- `client.rln` for RGB Lightning Node wallet, channel, payment, and swap endpoints
 
 ## Installation
 
 <CodeGroup>
 ```bash npm
-npm install kaleidoswap-sdk
+npm install kaleido-sdk
 ```
 
 ```bash pnpm
-pnpm add kaleidoswap-sdk
+pnpm add kaleido-sdk
 ```
 
 ```bash yarn
-yarn add kaleidoswap-sdk
+yarn add kaleido-sdk
 ```
 
 ```bash pip
-pip install kaleidoswap-sdk
+pip install kaleido-sdk
 ```
 </CodeGroup>
 
@@ -42,117 +37,109 @@ pip install kaleidoswap-sdk
 <Tabs>
   <Tab title="TypeScript">
     - Node.js 18 or higher
-    - TypeScript 5.0+ (recommended)
+    - TypeScript 5.x recommended
   </Tab>
   <Tab title="Python">
     - Python 3.10 or higher
-    - Dependencies installed automatically: `httpx`, `websockets`, `pydantic`
+    - Runtime dependencies are installed automatically
   </Tab>
 </Tabs>
 
-## Configuration
-
-### Basic Setup
+## Basic Setup
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: 'https://api.regtest.kaleidoswap.com',
 });
 
-// Make your first API call
 const assets = await client.maker.listAssets();
 console.log(`Found ${assets.assets.length} assets`);
 ```
 
 ```python Python
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 client = KaleidoClient.create(
     base_url="https://api.regtest.kaleidoswap.com"
 )
 
-# Make your first API call
 assets = await client.maker.list_assets()
 print(f"Found {len(assets.assets)} assets")
 ```
 </CodeGroup>
 
 <Note>
-`KaleidoClient.create()` is **synchronous** in both languages. No `await` is needed for client creation.
+`KaleidoClient.create()` is synchronous in both SDKs. Do not `await` client creation.
 </Note>
 
-### Full Configuration
+## Configuration
 
-<CodeGroup>
-```typescript TypeScript
-import { KaleidoClient, KaleidoConfig } from 'kaleidoswap-sdk';
+### TypeScript
 
-const config: KaleidoConfig = {
-  // Required: API base URL
+`KaleidoClient.create()` accepts a `KaleidoConfig` object:
+
+```typescript
+import { KaleidoClient, LogLevel } from 'kaleido-sdk';
+
+const client = KaleidoClient.create({
   baseUrl: 'https://api.regtest.kaleidoswap.com',
-
-  // Optional: Your RGB Lightning Node URL
   nodeUrl: 'http://localhost:3001',
-
-  // Optional: API key for authenticated requests
-  apiKey: undefined,
-
-  // Optional: Request timeout in seconds (default: 30)
+  apiKey: process.env.KALEIDO_API_KEY,
   timeout: 30,
-
-  // Optional: Maximum retries (default: 3)
-  maxRetries: 3,
-
-  // Optional: Cache TTL in seconds (default: 60)
-  cacheTtl: 60,
-};
-
-const client = KaleidoClient.create(config);
+  logLevel: LogLevel.INFO,
+});
 ```
 
-```python Python
-from kaleidoswap_sdk import KaleidoClient
+Supported config fields:
+
+- `baseUrl?`: Maker API base URL. Defaults to `https://api.regtest.kaleidoswap.com`
+- `nodeUrl?`: RGB Lightning Node URL
+- `apiKey?`: optional API key
+- `timeout?`: request timeout in seconds
+- `logLevel?`: SDK log level
+- `logger?`: custom logger implementation
+
+### Python
+
+`KaleidoClient.create()` accepts keyword arguments:
+
+```python
+import logging
+from kaleido_sdk import KaleidoClient
 
 client = KaleidoClient.create(
-    # Required: API base URL
     base_url="https://api.regtest.kaleidoswap.com",
-
-    # Optional: Your RGB Lightning Node URL
     node_url="http://localhost:3001",
-
-    # Optional: API key for authenticated requests
     api_key=None,
-
-    # Optional: Request timeout in seconds (default: 30)
     timeout=30.0,
-
-    # Optional: Maximum retries (default: 3)
     max_retries=3,
-
-    # Optional: Cache TTL in seconds (default: 60)
     cache_ttl=60,
+    log_level=logging.INFO,
 )
 ```
-</CodeGroup>
 
-### Environment Variables
+Python supports the same connection settings plus:
 
-You can pass the same options via environment variables. Supported names:
+- `max_retries`: retry budget for the HTTP client
+- `cache_ttl`: cache TTL in seconds
+- `log_level`: standard Python logging level
 
-| Variable | Maps to | Required |
-|----------|---------|----------|
-| `KALEIDO_API_URL` | `baseUrl` | Yes (or use default in code) |
-| `KALEIDO_NODE_URL` | `nodeUrl` | No (needed for wallet/channel operations) |
-| `KALEIDO_API_KEY` | `apiKey` | No |
+## Environment Variables
 
-Example: read them in code and pass to `KaleidoClient.create()` (if you use a `.env` file, load it first with your usual tool, e.g. `dotenv` in Node).
+The SDK does not auto-load environment variables, but these names are used by the examples and work well as a convention:
+
+| Variable | Typical use |
+|----------|-------------|
+| `KALEIDO_API_URL` | Maker API base URL |
+| `KALEIDO_NODE_URL` | RGB Lightning Node URL |
+| `KALEIDO_API_KEY` | API key |
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: process.env.KALEIDO_API_URL || 'https://api.regtest.kaleidoswap.com',
@@ -163,7 +150,7 @@ const client = KaleidoClient.create({
 
 ```python Python
 import os
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 client = KaleidoClient.create(
     base_url=os.environ.get("KALEIDO_API_URL", "https://api.regtest.kaleidoswap.com"),
@@ -175,151 +162,105 @@ client = KaleidoClient.create(
 
 ## Available Environments
 
-| Environment | API URL | Description |
-|-------------|---------|-------------|
-| **Regtest** | `https://api.regtest.kaleidoswap.com` | Local development and testing |
-| **Signet** | `https://api.signet.kaleidoswap.com` | Bitcoin Signet testnet |
-| **Mainnet** | `https://api.kaleidoswap.com` | Production environment *(Coming Soon)* |
+Common Maker API endpoints used in this repo:
+
+| Environment | API URL |
+|-------------|---------|
+| Regtest | `https://api.regtest.kaleidoswap.com` |
+| Signet / staging | `https://api.staging.kaleidoswap.com` |
+| Signet | `https://api.signet.kaleidoswap.com` |
 
 ## Sub-Client Architecture
 
-The SDK organizes API operations into two sub-clients:
-
 <CodeGroup>
 ```typescript TypeScript
-// Maker operations (market, orders, swaps, LSPS1)
-const assets = await client.maker.listAssets();
+const client = KaleidoClient.create({
+  baseUrl: 'https://api.regtest.kaleidoswap.com',
+  nodeUrl: 'http://localhost:3001',
+});
+
 const pairs = await client.maker.listPairs();
-const quote = await client.maker.getQuote({ /* ... */ });
-const order = await client.maker.createSwapOrder({ /* ... */ });
-const status = await client.maker.getSwapOrderStatus({ order_id: 'order-123' });
-const history = await client.maker.getOrderHistory();
-const lspInfo = await client.maker.getLspInfo();
 
-// RLN operations (wallet, channels, payments -- requires nodeUrl)
 if (client.hasNode()) {
   const nodeInfo = await client.rln.getNodeInfo();
-  const balance = await client.rln.getBtcBalance();
   const channels = await client.rln.listChannels();
-  const invoice = await client.rln.createLNInvoice({ /* ... */ });
 }
 ```
 
 ```python Python
-from kaleidoswap_sdk import (
-    PairQuoteRequest,
-    CreateSwapOrderRequest,
-    SwapOrderStatusRequest,
-    LNInvoiceRequest
+client = KaleidoClient.create(
+    base_url="https://api.regtest.kaleidoswap.com",
+    node_url="http://localhost:3001",
 )
 
-# Maker operations (market, orders, swaps, LSPS1)
-assets = await client.maker.list_assets()
 pairs = await client.maker.list_pairs()
-quote = await client.maker.get_quote(PairQuoteRequest(...))
-order = await client.maker.create_swap_order(CreateSwapOrderRequest(...))
-status = await client.maker.get_swap_order_status(SwapOrderStatusRequest(order_id="order-123"))
-history = await client.maker.get_order_history()
-lsp_info = await client.maker.get_lsp_info()
 
-# RLN operations (wallet, channels, payments -- requires node_url)
 if client.has_node():
     node_info = await client.rln.get_node_info()
-    balance = await client.rln.get_btc_balance()
     channels = await client.rln.list_channels()
-    invoice = await client.rln.create_ln_invoice(LNInvoiceRequest(...))
 ```
 </CodeGroup>
 
-## Checking Node Configuration
+## Node Configuration Checks
 
-Before executing node operations, verify that your node is configured:
+TypeScript exposes `client.hasNode()` and always returns an `rln` client instance. Python exposes `client.has_node()`, and `client.rln` raises `NodeNotConfiguredError` if `node_url` is missing.
 
 <CodeGroup>
 ```typescript TypeScript
-if (client.hasNode()) {
-  console.log('Node configured - can access RLN operations');
-  const nodeInfo = await client.rln.getNodeInfo();
-  console.log(`Node pubkey: ${nodeInfo.pubkey}`);
+if (!client.hasNode()) {
+  console.log('Node URL not configured; only maker operations are available');
 } else {
-  console.log('Node not configured - limited to maker operations');
+  const nodeInfo = await client.rln.getNodeInfo();
+  console.log(nodeInfo.pubkey);
 }
 ```
 
 ```python Python
-if client.has_node():
-    print("Node configured - can access RLN operations")
-    node_info = await client.rln.get_node_info()
-    print(f"Node pubkey: {node_info.pubkey}")
+if not client.has_node():
+    print("Node URL not configured; only maker operations are available")
 else:
-    print("Node not configured - limited to maker operations")
+    node_info = await client.rln.get_node_info()
+    print(node_info.pubkey)
 ```
 </CodeGroup>
 
-## Basic Error Handling
+## First Quote
 
 <CodeGroup>
 ```typescript TypeScript
-import {
-  KaleidoClient,
-  KaleidoError,
-  NetworkError,
-  ValidationError,
-  APIError,
-} from 'kaleidoswap-sdk';
+import { KaleidoClient, Layer } from 'kaleido-sdk';
 
-try {
-  const pairs = await client.maker.listPairs();
-  console.log(`Found ${pairs.pairs.length} pairs`);
-} catch (error) {
-  if (error instanceof NetworkError) {
-    console.log(`Network error: ${error.message}`);
-  } else if (error instanceof ValidationError) {
-    console.log(`Validation error: ${error.message}`);
-  } else if (error instanceof APIError) {
-    console.log(`API error (${error.statusCode}): ${error.message}`);
-  } else if (error instanceof KaleidoError) {
-    console.log(`SDK error: ${error.message}`);
-  }
-}
+const client = KaleidoClient.create();
+
+const quote = await client.maker.getQuote({
+  from_asset: {
+    asset_id: 'BTC',
+    layer: Layer.BTC_LN,
+    amount: 100000,
+  },
+  to_asset: {
+    asset_id: 'USDT',
+    layer: Layer.RGB_LN,
+  },
+});
+
+console.log(quote.rfq_id);
+console.log(quote.price);
 ```
 
 ```python Python
-from kaleidoswap_sdk import (
-    KaleidoClient,
-    KaleidoError,
-    NetworkError,
-    ValidationError,
-    APIError,
+from kaleido_sdk import KaleidoClient, Layer, PairQuoteRequest, SwapLegInput
+
+client = KaleidoClient.create()
+
+quote = await client.maker.get_quote(
+    PairQuoteRequest(
+        from_asset=SwapLegInput(asset_id="BTC", layer=Layer.BTC_LN, amount=100000),
+        to_asset=SwapLegInput(asset_id="USDT", layer=Layer.RGB_LN),
+    )
 )
 
-try:
-    pairs = await client.maker.list_pairs()
-    print(f"Found {len(pairs.pairs)} pairs")
-except NetworkError as e:
-    print(f"Network error: {e}")
-except ValidationError as e:
-    print(f"Validation error: {e}")
-except APIError as e:
-    print(f"API error ({e.status_code}): {e}")
-except KaleidoError as e:
-    print(f"SDK error: {e}")
+print(quote.rfq_id)
+print(quote.price)
 ```
 </CodeGroup>
-
-## Next Steps
-
-<CardGroup cols={2}>
-  <Card title="Examples" icon="code" href="/sdk/examples">
-    See complete code examples for common use cases
-  </Card>
-  <Card title="API Reference" icon="book" href="/sdk/api-reference">
-    Explore all available methods and parameters
-  </Card>
-  <Card title="Types" icon="brackets-curly" href="/sdk/types">
-    Learn about data models and type definitions
-  </Card>
-  <Card title="Error Handling" icon="triangle-exclamation" href="/sdk/error-handling">
-    Handle errors gracefully in your applications
-  </Card>
-</CardGroup>

--- a/mintlify-docs/sdk/how-to-swap.mdx
+++ b/mintlify-docs/sdk/how-to-swap.mdx
@@ -7,7 +7,7 @@ description: "Step-by-step guide for creating and executing swap orders and atom
 
 This guide provides a detailed walkthrough on how to execute both Order-Based Swaps (custodial/invoicing) and Atomic Swaps (direct node-to-node) using the Kaleido Python SDK.
 
-These examples leverage the Pydantic models from `kaleidoswap_sdk` to ensure type safety and precise API interactions.
+These examples leverage the Pydantic models from `kaleido_sdk` to ensure type safety and precise API interactions.
 
 ---
 
@@ -18,7 +18,7 @@ Swap orders involve locking in a rate via a quote and receiving a deposit addres
 ### Prerequisites & Imports
 
 ```python Python
-from kaleidoswap_sdk import (
+from kaleido_sdk import (
     CreateSwapOrderRequest,
     KaleidoClient,
     Layer,
@@ -101,7 +101,7 @@ Atomic Swaps allow direct, trustless node-to-node exchange using RGB Lightning N
 ### Prerequisites & Imports
 
 ```python Python
-from kaleidoswap_sdk import (
+from kaleido_sdk import (
     ConfirmSwapRequest,
     InitiateSwapRequest,
     KaleidoClient,
@@ -109,7 +109,7 @@ from kaleidoswap_sdk import (
     PairQuoteRequest,
     SwapLegInput,
 )
-from kaleidoswap_sdk.rln import TakerRequest
+from kaleido_sdk.rln import TakerRequest
 
 client = KaleidoClient.create(
     base_url="https://api.signet.kaleidoswap.com",

--- a/mintlify-docs/sdk/maker-api-compatibility.mdx
+++ b/mintlify-docs/sdk/maker-api-compatibility.mdx
@@ -30,7 +30,7 @@ To use Maker API features with the SDK:
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: 'https://api.regtest.kaleidoswap.com',
@@ -44,7 +44,7 @@ const quote = await client.maker.getQuote({ asset_id: '...', network: 'BTC' });
 
 ```python Python
 import asyncio
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 async def main():
     client = KaleidoClient.create(

--- a/mintlify-docs/sdk/rln-api-compatibility.mdx
+++ b/mintlify-docs/sdk/rln-api-compatibility.mdx
@@ -33,7 +33,7 @@ Before using RLN operations, ensure your node is configured:
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: 'https://api.signet.kaleidoswap.com',
@@ -53,7 +53,7 @@ if (client.hasNode()) {
 
 ```python Python
 import asyncio
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 
 async def main():

--- a/mintlify-docs/sdk/troubleshooting.mdx
+++ b/mintlify-docs/sdk/troubleshooting.mdx
@@ -7,32 +7,32 @@ description: 'Common issues and solutions'
 
 <AccordionGroup>
   <Accordion title="npm install fails (TypeScript)">
-    **Symptoms:** `npm install kaleidoswap-sdk` fails with errors
+    **Symptoms:** `npm install kaleido-sdk` fails with errors
 
     **Solutions:**
     1. Ensure Node.js 18+ is installed: `node --version`
     2. Clear npm cache: `npm cache clean --force`
     3. Delete `node_modules` and `package-lock.json`, then reinstall
-    4. Try with a different package manager: `pnpm add kaleidoswap-sdk`
+    4. Try with a different package manager: `pnpm add kaleido-sdk`
   </Accordion>
 
   <Accordion title="pip install fails (Python)">
-    **Symptoms:** `pip install kaleidoswap-sdk` fails
+    **Symptoms:** `pip install kaleido-sdk` fails
 
     **Solutions:**
     1. Ensure Python 3.10+ is installed: `python --version`
     2. Use a virtual environment: `python -m venv .venv && source .venv/bin/activate`
     3. Upgrade pip: `pip install --upgrade pip`
-    4. Try: `pip install kaleidoswap-sdk --no-cache-dir`
+    4. Try: `pip install kaleido-sdk --no-cache-dir`
   </Accordion>
 
   <Accordion title="Module not found after installation">
-    **Symptoms:** `Cannot find module 'kaleidoswap-sdk'` or `ModuleNotFoundError`
+    **Symptoms:** `Cannot find module 'kaleido-sdk'` or `ModuleNotFoundError`
 
     **Solutions:**
     - **TypeScript:** Check your `tsconfig.json` has `"moduleResolution": "node"` or `"bundler"`
     - **Python:** Verify you are in the correct virtual environment
-    - Verify the package is installed: `npm list kaleidoswap-sdk` or `pip show kaleidoswap-sdk`
+    - Verify the package is installed: `npm list kaleido-sdk` or `pip show kaleido-sdk`
   </Accordion>
 </AccordionGroup>
 
@@ -106,14 +106,14 @@ description: 'Common issues and solutions'
 
     <CodeGroup>
     ```typescript TypeScript
-    import { toSmallestUnits } from 'kaleidoswap-sdk';
+    import { toSmallestUnits } from 'kaleido-sdk';
 
     // Convert 0.001 BTC to satoshis (100000)
     const amount = toSmallestUnits(0.001, 8);
     ```
 
     ```python Python
-    from kaleidoswap_sdk import to_smallest_units
+    from kaleido_sdk import to_smallest_units
 
     # Convert 0.001 BTC to satoshis (100000)
     amount = to_smallest_units(0.001, 8)
@@ -205,9 +205,9 @@ description: 'Common issues and solutions'
     **Symptoms:** TypeScript compiler errors about incompatible types
 
     **Solutions:**
-    1. Ensure you are importing types from `kaleidoswap-sdk`:
+    1. Ensure you are importing types from `kaleido-sdk`:
        ```typescript
-       import type { Asset, TradingPair } from 'kaleidoswap-sdk';
+       import type { Asset, TradingPair } from 'kaleido-sdk';
        ```
     2. Check your TypeScript version is 5.0+
     3. If using strict mode, you may need to handle `undefined` explicitly
@@ -220,7 +220,7 @@ description: 'Common issues and solutions'
     1. The SDK is ESM-only. Ensure your project uses ESM:
        - `"type": "module"` in `package.json`
        - Or use `.mts` file extension
-    2. If you must use CommonJS, use dynamic import: `const sdk = await import('kaleidoswap-sdk')`
+    2. If you must use CommonJS, use dynamic import: `const sdk = await import('kaleido-sdk')`
   </Accordion>
 </AccordionGroup>
 
@@ -233,7 +233,7 @@ description: 'Common issues and solutions'
     **Solutions:**
     1. Ensure `pydantic>=2.0` is installed
     2. Check that you are using the correct request format
-    3. The API may have been updated -- try updating the SDK: `pip install --upgrade kaleidoswap-sdk`
+    3. The API may have been updated -- try updating the SDK: `pip install --upgrade kaleido-sdk`
   </Accordion>
 
   <Accordion title="httpx connection errors">

--- a/mintlify-docs/sdk/types.mdx
+++ b/mintlify-docs/sdk/types.mdx
@@ -1,424 +1,191 @@
 ---
 title: 'Types'
-description: 'Type definitions and data models used by the SDK'
+description: 'Core types and config used by the Kaleido SDK'
 ---
 
 ## Overview
 
-Both SDKs auto-generate types from the same OpenAPI specifications, ensuring consistency:
+The SDK ships generated API models plus a thin handwritten client layer.
 
-- **TypeScript**: Types generated via `openapi-fetch` with full type inference
-- **Python**: Pydantic models generated from the OpenAPI specs
+- TypeScript exports its request and response types from `kaleido-sdk`
+- Python exports Pydantic models from `kaleido_sdk`
 
-## Configuration
+## Client Config
 
-### KaleidoConfig
+### TypeScript
+
+```typescript
+import type { KaleidoConfig } from 'kaleido-sdk';
+
+const config: KaleidoConfig = {
+  baseUrl: 'https://api.regtest.kaleidoswap.com',
+  nodeUrl: 'http://localhost:3001',
+  apiKey: process.env.KALEIDO_API_KEY,
+  timeout: 30,
+  logLevel: 'info',
+  logger: console,
+};
+```
+
+`KaleidoConfig` currently supports:
+
+- `baseUrl?`
+- `nodeUrl?`
+- `apiKey?`
+- `timeout?`
+- `logLevel?`
+- `logger?`
+
+### Python
+
+Python does not expose a separate constructor object for normal use. Configure the client via `KaleidoClient.create(...)`:
+
+```python
+import logging
+from kaleido_sdk import KaleidoClient
+
+client = KaleidoClient.create(
+    base_url="https://api.regtest.kaleidoswap.com",
+    node_url="http://localhost:3001",
+    api_key=None,
+    timeout=30.0,
+    max_retries=3,
+    cache_ttl=60,
+    log_level=logging.INFO,
+)
+```
+
+## Common Enums and Models
 
 <CodeGroup>
 ```typescript TypeScript
-interface KaleidoConfig {
-  baseUrl: string;        // Required: API base URL
-  nodeUrl?: string;       // Optional: RGB Lightning Node URL
-  apiKey?: string;        // Optional: API key
-  timeout?: number;       // Optional: timeout in seconds (default: 30)
-  maxRetries?: number;    // Optional: max retries (default: 3)
-  cacheTtl?: number;      // Optional: cache TTL in seconds (default: 60)
-}
+import type {
+  Asset,
+  CreateSwapOrderRequest,
+  PairQuoteRequest,
+  PairQuoteResponse,
+  SwapOrderStatusRequest,
+  TradingPair,
+} from 'kaleido-sdk';
+import { Layer, ReceiverAddressFormat } from 'kaleido-sdk';
 ```
 
 ```python Python
-# KaleidoClient.create() accepts keyword arguments:
-KaleidoClient.create(
-    base_url: str,               # Required
-    node_url: str | None,        # Optional
-    api_key: str | None,         # Optional
-    timeout: float = 30.0,       # Optional
-    max_retries: int = 3,        # Optional
-    cache_ttl: int = 60,         # Optional
+from kaleido_sdk import (
+    Asset,
+    CreateSwapOrderRequest,
+    Layer,
+    PairQuoteRequest,
+    PairQuoteResponse,
+    ReceiverAddressFormat,
+    SwapOrderStatusRequest,
+    TradingPair,
 )
 ```
 </CodeGroup>
 
-## Layer Types
+## Layers
 
-The `Layer` type defines all supported network layers for asset transfers.
+The SDK uses the shared `Layer` enum for routing assets across supported networks.
 
 <CodeGroup>
 ```typescript TypeScript
-type Layer =
-  | 'BTC_L1'           // Bitcoin on-chain
-  | 'BTC_LN'           // Bitcoin Lightning
-  | 'BTC_SPARK'        // Bitcoin Spark
-  | 'BTC_ARKADE'       // Bitcoin Arkade
-  | 'BTC_LIQUID'       // Bitcoin Liquid
-  | 'BTC_CASHU'        // Bitcoin Cashu
-  | 'RGB_L1'           // RGB on-chain
-  | 'RGB_LN'           // RGB Lightning
-  | 'TAPASS_L1'        // Taproot Assets on-chain
-  | 'TAPASS_LN'        // Taproot Assets Lightning
-  | 'LIQUID_LIQUID'    // Liquid network
-  | 'ARKADE_ARKADE'    // Arkade network
-  | 'SPARK_SPARK';     // Spark network
+import { Layer } from 'kaleido-sdk';
 
-// Runtime enum for Layer values
-import { LayerEnum } from 'kaleidoswap-sdk';
-const layer = LayerEnum.BTC_LN;
+const fromLayer = Layer.BTC_LN;
+const toLayer = Layer.RGB_LN;
 ```
 
 ```python Python
-from kaleidoswap_sdk.generated.api_types import Layer
+from kaleido_sdk import Layer
 
-# Layer is a string enum:
-# "BTC_L1", "BTC_LN", "BTC_SPARK", "BTC_ARKADE",
-# "BTC_LIQUID", "BTC_CASHU", "RGB_L1", "RGB_LN",
-# "TAPASS_L1", "TAPASS_LN", "LIQUID_LIQUID",
-# "ARKADE_ARKADE", "SPARK_SPARK"
+from_layer = Layer.BTC_LN
+to_layer = Layer.RGB_LN
 ```
 </CodeGroup>
 
 ## Receiver Address Formats
 
-The `ReceiverAddressFormat` type defines address formats for each layer.
+Use `ReceiverAddressFormat` when creating order-based swaps that need a destination.
 
 <CodeGroup>
 ```typescript TypeScript
-type ReceiverAddressFormat =
-  | 'BTC_ADDRESS'        // Standard Bitcoin address (bc1q...)
-  | 'BOLT11'             // Lightning BOLT11 invoice
-  | 'BOLT12'             // Lightning BOLT12 offer
-  | 'LN_ADDRESS'         // Lightning Address (user@domain)
-  | 'RGB_INVOICE'        // RGB invoice
-  | 'LIQUID_ADDRESS'     // Liquid address
-  | 'LIQUID_INVOICE'     // Liquid invoice
-  | 'SPARK_ADDRESS'      // Spark address
-  | 'SPARK_INVOICE'      // Spark invoice
-  | 'ARKADE_ADDRESS'     // Arkade address
-  | 'ARKADE_INVOICE'     // Arkade invoice
-  | 'CASHU_TOKEN';       // Cashu token
+import { ReceiverAddressFormat } from 'kaleido-sdk';
 
-import { ReceiverAddressFormatEnum } from 'kaleidoswap-sdk';
-const format = ReceiverAddressFormatEnum.BOLT11;
+const format = ReceiverAddressFormat.BOLT11;
 ```
 
 ```python Python
-from kaleidoswap_sdk.generated.api_types import ReceiverAddressFormat
+from kaleido_sdk import ReceiverAddressFormat
 
-# ReceiverAddressFormat is a string enum:
-# "BTC_ADDRESS", "BOLT11", "BOLT12", "LN_ADDRESS",
-# "RGB_INVOICE", "LIQUID_ADDRESS", "LIQUID_INVOICE",
-# "SPARK_ADDRESS", "SPARK_INVOICE", "ARKADE_ADDRESS",
-# "ARKADE_INVOICE", "CASHU_TOKEN"
+format = ReceiverAddressFormat.BOLT11
 ```
 </CodeGroup>
 
-## Market Types
-
-### Asset
-
-Represents a tradeable asset.
+## Quote Models
 
 <CodeGroup>
 ```typescript TypeScript
-// Auto-generated from OpenAPI
-type Asset = components['schemas']['Asset'];
-// Fields: asset_id, ticker, name, precision, ...
+import type { PairQuoteRequest, PairQuoteResponse } from 'kaleido-sdk';
+
+const request: PairQuoteRequest = {
+  from_asset: { asset_id: 'BTC', layer: Layer.BTC_LN, amount: 100000 },
+  to_asset: { asset_id: 'USDT', layer: Layer.RGB_LN },
+};
+
+const response: PairQuoteResponse = await client.maker.getQuote(request);
 ```
 
 ```python Python
-# Pydantic model from OpenAPI
-from kaleidoswap_sdk.generated.api_types import Asset
-# Fields: asset_id, ticker, name, precision, ...
-```
-</CodeGroup>
+from kaleido_sdk import Layer, PairQuoteRequest, SwapLegInput
 
-### TradingPair
-
-Represents a trading pair with routes and limits.
-
-<CodeGroup>
-```typescript TypeScript
-type TradingPair = components['schemas']['TradingPair'];
-// Fields: base_asset_ticker, quote_asset_ticker, routes, ...
-```
-
-```python Python
-from kaleidoswap_sdk.generated.api_types import TradingPair
-# Fields: base_asset_ticker, quote_asset_ticker, routes, ...
-```
-</CodeGroup>
-
-### Quote / PairQuoteResponse
-
-A price quote for a swap.
-
-<CodeGroup>
-```typescript TypeScript
-type Quote = components['schemas']['PairQuoteResponse'];
-// Fields: rfq_id, from_amount, to_amount, price, expires_at, fee, ...
-```
-
-```python Python
-from kaleidoswap_sdk.generated.api_types import PairQuoteResponse
-# Fields: rfq_id, from_amount, to_amount, price, expires_at, fee, ...
-```
-</CodeGroup>
-
-### Fee
-
-Fee structure returned in quotes.
-
-<CodeGroup>
-```typescript TypeScript
-// From WebSocket types
-interface Fee {
-  fee_asset: string;
-  fee_precision: number;
-  base_fee: number;
-  variable_fee: number;
-  fee_rate: number;
-  final_fee: number;
-}
-```
-
-```python Python
-# Fee fields in quote responses:
-# fee_asset, fee_precision, base_fee, variable_fee, fee_rate, final_fee
-```
-</CodeGroup>
-
-## Order Types
-
-### CreateSwapOrderRequest
-
-Request to create a swap order.
-
-<CodeGroup>
-```typescript TypeScript
-type CreateSwapOrderRequest = components['schemas']['CreateSwapOrderRequest'];
-// Fields: rfq_id, from_asset, to_asset, receiver_address, min_onchain_conf
-```
-
-```python Python
-from kaleidoswap_sdk.generated.api_types import CreateSwapOrderRequest
-# Fields: rfq_id, from_asset, to_asset, receiver_address, min_onchain_conf
-```
-</CodeGroup>
-
-### SwapOrder
-
-A swap order with full details.
-
-<CodeGroup>
-```typescript TypeScript
-type SwapOrder = components['schemas']['SwapOrder'];
-// Fields: order_id, status, from_asset, to_asset, deposit_address, ...
-```
-
-```python Python
-from kaleidoswap_sdk.generated.api_types import SwapOrder
-# Fields: order_id, status, from_asset, to_asset, deposit_address, ...
-```
-</CodeGroup>
-
-### Order State Enums
-
-<CodeGroup>
-```typescript TypeScript
-type OrderState = components['schemas']['OrderState'];
-// Values: CREATED, PENDING_PAYMENT, PAID, EXECUTING,
-//         FILLED, EXPIRED, CANCELLED, FAILED, PENDING_RATE_DECISION
-
-type PaymentState = components['schemas']['PaymentState'];
-// Values: NOT_PAID, PAID, OVERPAID, UNDERPAID
-
-type PaymentStatus = components['schemas']['PaymentStatus'];
-// Payment processing status
-```
-
-```python Python
-from kaleidoswap_sdk.generated.api_types import OrderState, PaymentState, PaymentStatus
-# Same enum values as TypeScript
-```
-</CodeGroup>
-
-## Node Types (RLN)
-
-These types are used with `client.rln` operations. They are auto-generated from the RLN node OpenAPI spec.
-
-### NodeInfoResponse
-
-<CodeGroup>
-```typescript TypeScript
-type NodeInfoResponse = nodeComponents['schemas']['NodeInfoResponse'];
-// Fields: pubkey, alias, color, num_channels, ...
-```
-
-```python Python
-from kaleidoswap_sdk.generated.node_types import NodeInfoResponse
-# Fields: pubkey, alias, color, num_channels, ...
-```
-</CodeGroup>
-
-### BtcBalanceResponse
-
-<CodeGroup>
-```typescript TypeScript
-type BtcBalanceResponse = nodeComponents['schemas']['BtcBalanceResponse'];
-// Fields: vanilla { settled, future, spendable }, colored { settled, future, spendable }
-```
-
-```python Python
-from kaleidoswap_sdk.generated.node_types import BtcBalanceResponse
-# Fields: vanilla.settled, vanilla.future, vanilla.spendable, colored.settled, ...
-```
-</CodeGroup>
-
-### Channel
-
-<CodeGroup>
-```typescript TypeScript
-type Channel = nodeComponents['schemas']['Channel'];
-// Fields: channel_id, peer_pubkey, capacity, local_balance, status, ...
-```
-
-```python Python
-from kaleidoswap_sdk.generated.node_types import Channel
-# Fields: channel_id, peer_pubkey, capacity, local_balance, status, ...
-```
-</CodeGroup>
-
-### Invoice Types
-
-<CodeGroup>
-```typescript TypeScript
-type LNInvoiceResponse = nodeComponents['schemas']['LNInvoiceResponse'];
-type RgbInvoiceResponse = nodeComponents['schemas']['RgbInvoiceResponse'];
-type DecodeLNInvoiceResponse = nodeComponents['schemas']['DecodeLNInvoiceResponse'];
-```
-
-```python Python
-from kaleidoswap_sdk.generated.node_types import (
-    LNInvoiceResponse,
-    RgbInvoiceResponse,
-    DecodeLNInvoiceResponse,
+request = PairQuoteRequest(
+    from_asset=SwapLegInput(asset_id="BTC", layer=Layer.BTC_LN, amount=100000),
+    to_asset=SwapLegInput(asset_id="USDT", layer=Layer.RGB_LN),
 )
+
+response = await client.maker.get_quote(request)
 ```
 </CodeGroup>
 
-### Asset Types
+## Order Models
 
 <CodeGroup>
 ```typescript TypeScript
-type AssetNIA = nodeComponents['schemas']['AssetNIA'];
-type ListAssetsResponse = nodeComponents['schemas']['ListAssetsResponse'];
-type AssetBalanceResponse = nodeComponents['schemas']['AssetBalanceResponse'];
-```
-
-```python Python
-from kaleidoswap_sdk.generated.node_types import (
-    AssetNIA,
-    ListAssetsResponse,
-    AssetBalanceResponse,
-)
-```
-</CodeGroup>
-
-## WebSocket Types
-
-<CodeGroup>
-```typescript TypeScript
-import type { QuoteResponse, QuoteRequest, PongResponse, Fee } from 'kaleidoswap-sdk';
-
-interface QuoteRequest {
-  from_asset: string;
-  to_asset: string;
-  from_amount?: number | null;
-  to_amount?: number | null;
-  from_layer?: string | null;
-  to_layer?: string | null;
-}
-
-interface QuoteResponse {
-  action: 'quote_response';
-  from_asset: string;
-  to_asset: string;
-  from_amount: number;
-  to_amount: number;
-  price: number;
-  rfq_id: string;
-  price_precision: number;
-  timestamp: number;
-  expires_at: number;
-  fee: Fee;
-}
-```
-
-```python Python
-# WebSocket messages are dictionaries in Python
-# QuoteRequest: from_asset, to_asset, from_amount, to_amount, from_layer, to_layer
-# QuoteResponse: action, from_asset, to_asset, from_amount, to_amount, price,
-#                rfq_id, price_precision, timestamp, expires_at, fee
-```
-</CodeGroup>
-
-## Importing Types
-
-<CodeGroup>
-```typescript TypeScript
-// Import specific types
 import type {
-  KaleidoConfig,
-  Asset,
-  TradingPair,
-  Quote,
   CreateSwapOrderRequest,
   SwapOrder,
-  Layer,
-  ReceiverAddressFormat,
-  BtcBalanceResponse,
-  Channel,
-} from 'kaleidoswap-sdk';
-
-// Import runtime enums
-import { LayerEnum, ReceiverAddressFormatEnum } from 'kaleidoswap-sdk';
-
-// Import raw OpenAPI components for advanced usage
-import type { components, paths } from 'kaleidoswap-sdk';
+  SwapOrderStatusRequest,
+  SwapOrderStatusResponse,
+} from 'kaleido-sdk';
 ```
 
 ```python Python
-# Import from generated types
-from kaleidoswap_sdk.generated.api_types import (
-    Asset,
-    TradingPair,
-    PairQuoteResponse,
+from kaleido_sdk import (
     CreateSwapOrderRequest,
     SwapOrder,
-    Layer,
-    ReceiverAddressFormat,
-)
-
-from kaleidoswap_sdk.generated.node_types import (
-    BtcBalanceResponse,
-    Channel,
-    NodeInfoResponse,
+    SwapOrderStatusRequest,
+    SwapOrderStatusResponse,
 )
 ```
 </CodeGroup>
 
-## Next Steps
+Notable fields used by the current client implementations:
 
-<CardGroup cols={2}>
-  <Card title="Client Reference" icon="code" href="/sdk/api-reference">
-    Browse all available methods on MakerClient and RlnClient
-  </Card>
-  <Card title="WebSocket" icon="bolt" href="/sdk/websocket">
-    Stream real-time quotes using the WebSocket API
-  </Card>
-  <Card title="Examples" icon="file-code" href="/sdk/examples">
-    See types in use across real-world code examples
-  </Card>
-  <Card title="Error Handling" icon="triangle-exclamation" href="/sdk/error-handling">
-    Handle errors with typed exceptions
-  </Card>
-</CardGroup>
+- `CreateSwapOrderRequest`: `rfq_id`, `from_asset`, `to_asset`, `receiver_address`, `min_onchain_conf?`
+- `CreateSwapOrderResponse`: `id`, `rfq_id`, `status`, `access_token`, `deposit_address?`
+- `SwapOrderStatusRequest`: `order_id`, `access_token?`
+
+## Utility Types
+
+TypeScript also exports WebSocket and logging-related types from the package root:
+
+```typescript
+import type { QuoteResponse, LogLevelValue, SdkLogger, SwapCompletionOptions } from 'kaleido-sdk';
+```
+
+Python exposes the polling helper type used by `wait_for_swap_completion(...)`:
+
+```python
+from kaleido_sdk import SwapCompletionOptions
+```

--- a/mintlify-docs/sdk/utilities.mdx
+++ b/mintlify-docs/sdk/utilities.mdx
@@ -11,14 +11,14 @@ Convert a display amount to the smallest unit (e.g., BTC to satoshis).
 
 <CodeGroup>
 ```typescript TypeScript
-import { toSmallestUnits } from 'kaleidoswap-sdk';
+import { toSmallestUnits } from 'kaleido-sdk';
 
 const sats = toSmallestUnits(0.001, 8);   // 100000
 const usdt = toSmallestUnits(10.50, 2);   // 1050
 ```
 
 ```python Python
-from kaleidoswap_sdk import to_smallest_units
+from kaleido_sdk import to_smallest_units
 
 sats = to_smallest_units(0.001, 8)   # 100000
 usdt = to_smallest_units(10.50, 2)   # 1050
@@ -31,14 +31,14 @@ Convert from smallest units back to display units.
 
 <CodeGroup>
 ```typescript TypeScript
-import { toDisplayUnits } from 'kaleidoswap-sdk';
+import { toDisplayUnits } from 'kaleido-sdk';
 
 const btc = toDisplayUnits(100000, 8);   // 0.001
 const usd = toDisplayUnits(1050, 2);     // 10.50
 ```
 
 ```python Python
-from kaleidoswap_sdk import to_display_units
+from kaleido_sdk import to_display_units
 
 btc = to_display_units(100000, 8)   # 0.001
 usd = to_display_units(1050, 2)     # 10.50
@@ -51,13 +51,13 @@ Equivalent to `toSmallestUnits`. Convert display to raw.
 
 <CodeGroup>
 ```typescript TypeScript
-import { toRawAmount } from 'kaleidoswap-sdk';
+import { toRawAmount } from 'kaleido-sdk';
 
 const raw = toRawAmount(0.5, 8);  // 50000000
 ```
 
 ```python Python
-from kaleidoswap_sdk import to_raw_amount
+from kaleido_sdk import to_raw_amount
 
 raw = to_raw_amount(0.5, 8)  # 50000000
 ```
@@ -69,13 +69,13 @@ Equivalent to `toDisplayUnits`. Convert raw to display.
 
 <CodeGroup>
 ```typescript TypeScript
-import { toDisplayAmount } from 'kaleidoswap-sdk';
+import { toDisplayAmount } from 'kaleido-sdk';
 
 const display = toDisplayAmount(50000000, 8);  // 0.5
 ```
 
 ```python Python
-from kaleidoswap_sdk import to_display_amount
+from kaleido_sdk import to_display_amount
 
 display = to_display_amount(50000000, 8)  # 0.5
 ```
@@ -89,7 +89,7 @@ The `PrecisionHandler` manages amount conversions for multiple assets, using the
 
 <CodeGroup>
 ```typescript TypeScript
-import { createPrecisionHandler } from 'kaleidoswap-sdk';
+import { createPrecisionHandler } from 'kaleido-sdk';
 
 // MappedAsset objects with asset_id and precision
 const assets = [
@@ -101,7 +101,7 @@ const handler = createPrecisionHandler(assets);
 ```
 
 ```python Python
-from kaleidoswap_sdk import create_precision_handler
+from kaleido_sdk import create_precision_handler
 
 assets = [
     {"asset_id": "btc-asset-id", "ticker": "BTC", "precision": 8},
@@ -209,7 +209,7 @@ The `AssetPairMapper` helps look up assets and trading pairs from the `listPairs
 ### Creating a Mapper
 
 ```typescript
-import { createAssetPairMapper } from 'kaleidoswap-sdk';
+import { createAssetPairMapper } from 'kaleido-sdk';
 
 const pairsResponse = await client.maker.listPairs();
 const mapper = createAssetPairMapper(pairsResponse);
@@ -288,12 +288,12 @@ Get the SDK version string.
 
 <CodeGroup>
 ```typescript TypeScript
-import { getVersion } from 'kaleidoswap-sdk';
+import { getVersion } from 'kaleido-sdk';
 console.log(getVersion());  // "0.4.0"
 ```
 
 ```python Python
-from kaleidoswap_sdk import get_version
+from kaleido_sdk import get_version
 print(get_version())  # "0.4.0"
 ```
 </CodeGroup>
@@ -304,13 +304,13 @@ Get the SDK package name.
 
 <CodeGroup>
 ```typescript TypeScript
-import { getSdkName } from 'kaleidoswap-sdk';
-console.log(getSdkName());  // "kaleidoswap-sdk"
+import { getSdkName } from 'kaleido-sdk';
+console.log(getSdkName());  // "kaleido-sdk"
 ```
 
 ```python Python
-from kaleidoswap_sdk import get_sdk_name
-print(get_sdk_name())  # "kaleidoswap-sdk"
+from kaleido_sdk import get_sdk_name
+print(get_sdk_name())  # "kaleido-sdk"
 ```
 </CodeGroup>
 

--- a/mintlify-docs/sdk/websocket.mdx
+++ b/mintlify-docs/sdk/websocket.mdx
@@ -54,7 +54,7 @@ unsubscribe();
 ```
 
 ```python Python
-from kaleidoswap_sdk import Layer
+from kaleido_sdk import Layer
 
 unsubscribe = await client.maker.stream_quotes_by_ticker(
     from_ticker="BTC",


### PR DESCRIPTION
…dk` to `kaleido-sdk` across all files. Adjust descriptions, installation instructions, and code examples accordingly. Ensure consistency in API references and error handling sections. Update environment variable references and configuration details for both TypeScript and Python SDKs. Revise utility functions and websocket examples to reflect the new package structure.