### PR TITLE
Update SDK version references to v0.1.2 in changelog, examples, getti…

### DIFF
--- a/mintlify-docs/sdk/changelog.mdx
+++ b/mintlify-docs/sdk/changelog.mdx
@@ -7,7 +7,7 @@ description: SDK and API version history for KaleidoSwap
   This changelog covers the KaleidoSwap SDK (`kaleido-sdk`) and the Maker API (`/api/v1`). For desktop app releases, see the [GitHub releases page](https://github.com/kaleidoswap/desktop-app/releases).
 </Note>
 
-## SDK v0.5.x — Current
+## SDK v0.1.2 — Current
 
 **Environments:** Regtest (`api.regtest.kaleidoswap.com`), Signet (`api.signet.kaleidoswap.com`)
 

--- a/mintlify-docs/sdk/examples.mdx
+++ b/mintlify-docs/sdk/examples.mdx
@@ -306,7 +306,7 @@ import { toSmallestUnits, toDisplayUnits, getSdkName, getVersion } from 'kaleido
 console.log(toSmallestUnits(0.001, 8)); // 100000
 console.log(toDisplayUnits(100000, 8)); // 0.001
 console.log(getSdkName());              // "kaleido-sdk"
-console.log(getVersion());              // "0.1.0"
+console.log(getVersion());              // "0.1.2"
 ```
 
 ```python Python
@@ -315,6 +315,6 @@ from kaleido_sdk import to_smallest_units, to_display_units, get_sdk_name, get_v
 print(to_smallest_units(0.001, 8))  # 100000
 print(to_display_units(100000, 8))  # 0.001
 print(get_sdk_name())               # "kaleido-sdk"
-print(get_version())                # "0.1.0"
+print(get_version())                # "0.1.2"
 ```
 </CodeGroup>

--- a/mintlify-docs/sdk/getting-started.mdx
+++ b/mintlify-docs/sdk/getting-started.mdx
@@ -5,7 +5,7 @@ description: 'Install and configure the Kaleido SDK for TypeScript or Python'
 
 ## Version Compatibility
 
-The current SDK implementation in `kaleidosdk` is `v0.1.0` for both TypeScript and Python.
+The current SDK implementation in `kaleidosdk` is `v0.1.2` for both TypeScript and Python.
 
 Both SDKs are generated from the same Maker API and RGB Lightning Node specs, then wrapped with handwritten clients for:
 

--- a/mintlify-docs/sdk/getting-started.mdx
+++ b/mintlify-docs/sdk/getting-started.mdx
@@ -5,7 +5,7 @@ description: 'Install and configure the Kaleido SDK for TypeScript or Python'
 
 ## Version Compatibility
 
-The current SDK implementation in `kaleidosdk` is `v0.1.2` for both TypeScript and Python.
+The current SDK implementation in `kaleido-sdk` (TypeScript) and `kaleido_sdk` (Python) is `v0.1.2`.
 
 Both SDKs are generated from the same Maker API and RGB Lightning Node specs, then wrapped with handwritten clients for:
 

--- a/mintlify-docs/sdk/maker-api-compatibility.mdx
+++ b/mintlify-docs/sdk/maker-api-compatibility.mdx
@@ -5,7 +5,7 @@ description: 'SDK and Maker API compatibility information'
 
 ## Compatibility
 
-**SDK v0.5.x** is compatible with the **latest Maker API** version.
+**SDK v0.1.2** is compatible with the **latest Maker API** version.
 
 The SDK automatically supports the most recent Maker API release. Always keep your SDK and Maker API updated to ensure full compatibility and access to the latest features.
 

--- a/mintlify-docs/sdk/rln-api-compatibility.mdx
+++ b/mintlify-docs/sdk/rln-api-compatibility.mdx
@@ -5,7 +5,7 @@ description: 'SDK and RGB Lightning Node API compatibility information'
 
 ## Compatibility
 
-**SDK v0.5.x** is compatible with the **latest RLN (RGB Lightning Node) API** version.
+**SDK v0.1.2** is compatible with the **latest RLN (RGB Lightning Node) API** version.
 
 The SDK automatically supports the most recent RLN API release. Always keep your SDK and RGB Lightning Node updated to ensure full compatibility and access to the latest features and security improvements.
 


### PR DESCRIPTION
…ng started, and compatibility documents