### PR TITLE
Rename kaleidoswap-sdk references to kaleido-sdk

### DIFF
--- a/mintlify-docs/api-reference/swap-protocol.mdx
+++ b/mintlify-docs/api-reference/swap-protocol.mdx
@@ -80,7 +80,7 @@ The SDK handles the WebSocket, init, and execute steps for you:
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: 'https://api.signet.kaleidoswap.com',
@@ -107,7 +107,7 @@ const unsubscribe = await client.maker.streamQuotesByTicker(
 ```
 
 ```python Python
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 client = KaleidoClient.create(
     base_url="https://api.signet.kaleidoswap.com",
@@ -180,7 +180,7 @@ Web Client / API User                Maker (RGB-LSP)
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: 'https://api.signet.kaleidoswap.com',
@@ -210,7 +210,7 @@ const completed = await client.maker.waitForSwapCompletion(order.order_id, {
 ```
 
 ```python Python
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 client = KaleidoClient.create(
     base_url="https://api.signet.kaleidoswap.com"

--- a/mintlify-docs/openapi.json
+++ b/mintlify-docs/openapi.json
@@ -41,12 +41,12 @@
           {
             "lang": "javascript",
             "label": "TypeScript SDK - Get LSP Info",
-            "source": "import { KaleidoClient } from '@kaleidoswap/kaleidoswap-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\nconst lspInfo = await client.getLspInfo();\nconsole.log(`LSP Pubkey: ${lspInfo.pubkey}`);\nconsole.log(`Connection URL: ${lspInfo.lsp_connection_url}`);"
+            "source": "import { KaleidoClient } from 'kaleido-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\nconst lspInfo = await client.getLspInfo();\nconsole.log(`LSP Pubkey: ${lspInfo.pubkey}`);\nconsole.log(`Connection URL: ${lspInfo.lsp_connection_url}`);"
           },
           {
             "lang": "python",
             "label": "Python SDK - Get LSP Info",
-            "source": "import asyncio\nfrom kaleidoswap_sdk import KaleidoClient\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        lsp_info = await client.get_lsp_info()\n        print(f\"LSP Pubkey: {lsp_info.pubkey}\")\n        print(f\"Connection URL: {lsp_info.lsp_connection_url}\")\n\nasyncio.run(main())"
+            "source": "import asyncio\nfrom kaleido_sdk import KaleidoClient\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        lsp_info = await client.get_lsp_info()\n        print(f\"LSP Pubkey: {lsp_info.pubkey}\")\n        print(f\"Connection URL: {lsp_info.lsp_connection_url}\")\n\nasyncio.run(main())"
           }
         ]
       }
@@ -396,12 +396,12 @@
           {
             "lang": "javascript",
             "label": "TypeScript SDK - Initialize Swap",
-            "source": "import { KaleidoClient } from '@kaleidoswap/kaleidoswap-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\n// First get a quote\nconst quote = await client.quoteRequest('BTC', 'rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak', 1000000);\n\n// Initialize the swap\nconst swap = await client.initMakerSwap({\n  rfq_id: quote.rfq_id,\n  from_asset: 'BTC',\n  to_asset: 'rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak',\n  from_amount: 1000000,\n  to_amount: quote.to_amount\n});\nconsole.log(`Swap initialized: ${swap.payment_hash}`);"
+            "source": "import { KaleidoClient } from 'kaleido-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\n// First get a quote\nconst quote = await client.quoteRequest('BTC', 'rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak', 1000000);\n\n// Initialize the swap\nconst swap = await client.initMakerSwap({\n  rfq_id: quote.rfq_id,\n  from_asset: 'BTC',\n  to_asset: 'rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak',\n  from_amount: 1000000,\n  to_amount: quote.to_amount\n});\nconsole.log(`Swap initialized: ${swap.payment_hash}`);"
           },
           {
             "lang": "python",
             "label": "Python SDK - Initialize Swap",
-            "source": "import asyncio\nfrom kaleidoswap_sdk import KaleidoClient, InitMakerSwapRequest\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        # First get a quote\n        quote = await client.get_quote(\n            from_asset=\"BTC\",\n            to_asset=\"rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak\",\n            amount=1000000\n        )\n        \n        # Initialize the swap\n        swap = await client.init_maker_swap(\n            InitMakerSwapRequest(\n                rfq_id=quote.rfq_id,\n                from_asset=\"BTC\",\n                to_asset=\"rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak\",\n                from_amount=1000000,\n                to_amount=quote.to_amount\n            )\n        )\n        print(f\"Swap initialized: {swap.payment_hash}\")\n\nasyncio.run(main())"
+            "source": "import asyncio\nfrom kaleido_sdk import KaleidoClient, InitMakerSwapRequest\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        # First get a quote\n        quote = await client.get_quote(\n            from_asset=\"BTC\",\n            to_asset=\"rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak\",\n            amount=1000000\n        )\n        \n        # Initialize the swap\n        swap = await client.init_maker_swap(\n            InitMakerSwapRequest(\n                rfq_id=quote.rfq_id,\n                from_asset=\"BTC\",\n                to_asset=\"rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak\",\n                from_amount=1000000,\n                to_amount=quote.to_amount\n            )\n        )\n        print(f\"Swap initialized: {swap.payment_hash}\")\n\nasyncio.run(main())"
           }
         ]
       }
@@ -537,12 +537,12 @@
           {
             "lang": "javascript",
             "label": "TypeScript SDK",
-            "source": "import { KaleidoClient } from '@kaleidoswap/kaleidoswap-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\nconst assets = await client.listAssets();\nconsole.log(`Found ${assets.assets.length} assets`);"
+            "source": "import { KaleidoClient } from 'kaleido-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\nconst assets = await client.listAssets();\nconsole.log(`Found ${assets.assets.length} assets`);"
           },
           {
             "lang": "python",
             "label": "Python SDK",
-            "source": "import asyncio\nfrom kaleidoswap_sdk import KaleidoClient\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        assets = await client.list_assets()\n        print(f\"Found {len(assets.assets)} assets\")\n\nasyncio.run(main())"
+            "source": "import asyncio\nfrom kaleido_sdk import KaleidoClient\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        assets = await client.list_assets()\n        print(f\"Found {len(assets.assets)} assets\")\n\nasyncio.run(main())"
           }
         ]
       }
@@ -581,12 +581,12 @@
           {
             "lang": "javascript",
             "label": "TypeScript SDK",
-            "source": "import { KaleidoClient } from '@kaleidoswap/kaleidoswap-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\nconst pairs = await client.listPairs();\nconsole.log(`Found ${pairs.pairs.length} trading pairs`);"
+            "source": "import { KaleidoClient } from 'kaleido-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\nconst pairs = await client.listPairs();\nconsole.log(`Found ${pairs.pairs.length} trading pairs`);"
           },
           {
             "lang": "python",
             "label": "Python SDK",
-            "source": "import asyncio\nfrom kaleidoswap_sdk import KaleidoClient\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        pairs = await client.list_pairs()\n        print(f\"Found {len(pairs.pairs)} trading pairs\")\n\nasyncio.run(main())"
+            "source": "import asyncio\nfrom kaleido_sdk import KaleidoClient\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        pairs = await client.list_pairs()\n        print(f\"Found {len(pairs.pairs)} trading pairs\")\n\nasyncio.run(main())"
           }
         ]
       }
@@ -646,12 +646,12 @@
           {
             "lang": "javascript",
             "label": "TypeScript SDK - BTC to USDT",
-            "source": "import { KaleidoClient } from '@kaleidoswap/kaleidoswap-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\nconst quote = await client.quoteRequest(\n  'BTC',\n  'rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak',\n  1000000 // 0.01 BTC minimum\n);\nconsole.log(`Exchange rate: ${quote.price}`);"
+            "source": "import { KaleidoClient } from 'kaleido-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\nconst quote = await client.quoteRequest(\n  'BTC',\n  'rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak',\n  1000000 // 0.01 BTC minimum\n);\nconsole.log(`Exchange rate: ${quote.price}`);"
           },
           {
             "lang": "python",
             "label": "Python SDK",
-            "source": "import asyncio\nfrom kaleidoswap_sdk import KaleidoClient\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        quote = await client.get_quote(\n            from_asset=\"BTC\",\n            to_asset=\"rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak\",\n            amount=1000000  # 0.01 BTC minimum\n        )\n        print(f\"Exchange rate: {quote.price}\")\n\nasyncio.run(main())"
+            "source": "import asyncio\nfrom kaleido_sdk import KaleidoClient\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        quote = await client.get_quote(\n            from_asset=\"BTC\",\n            to_asset=\"rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak\",\n            amount=1000000  # 0.01 BTC minimum\n        )\n        print(f\"Exchange rate: {quote.price}\")\n\nasyncio.run(main())"
           }
         ]
       }
@@ -706,12 +706,12 @@
           {
             "lang": "javascript",
             "label": "TypeScript SDK - Create Order",
-            "source": "import { KaleidoClient } from '@kaleidoswap/kaleidoswap-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\n// First get a quote\nconst quote = await client.quoteRequest('BTC', 'rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak', 1000000);\n\n// Create order\nconst order = await client.createOrder({\n  rfq_id: quote.rfq_id,\n  from_type: 'ONCHAIN',\n  to_type: 'LIGHTNING',\n  from_asset: 'BTC',\n  to_asset: 'rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak',\n  from_amount: 1000000,\n  to_amount: quote.to_amount\n});\nconsole.log(`Order created: ${order.id}`);"
+            "source": "import { KaleidoClient } from 'kaleido-sdk';\n\nconst client = new KaleidoClient({\n  baseUrl: 'https://api.staging.kaleidoswap.com/api/v1'\n});\n\n// First get a quote\nconst quote = await client.quoteRequest('BTC', 'rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak', 1000000);\n\n// Create order\nconst order = await client.createOrder({\n  rfq_id: quote.rfq_id,\n  from_type: 'ONCHAIN',\n  to_type: 'LIGHTNING',\n  from_asset: 'BTC',\n  to_asset: 'rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak',\n  from_amount: 1000000,\n  to_amount: quote.to_amount\n});\nconsole.log(`Order created: ${order.id}`);"
           },
           {
             "lang": "python",
             "label": "Python SDK - Create Order",
-            "source": "import asyncio\nfrom kaleidoswap_sdk import KaleidoClient, CreateOrderRequest\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        # First get a quote\n        quote = await client.get_quote(\n            from_asset=\"BTC\",\n            to_asset=\"rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak\",\n            amount=1000000\n        )\n        \n        # Create order\n        order = await client.create_order(\n            CreateOrderRequest(\n                rfq_id=quote.rfq_id,\n                from_type=\"ONCHAIN\",\n                to_type=\"LIGHTNING\",\n                from_asset=\"BTC\",\n                to_asset=\"rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak\",\n                from_amount=1000000,\n                to_amount=quote.to_amount\n            )\n        )\n        print(f\"Order created: {order.id}\")\n\nasyncio.run(main())"
+            "source": "import asyncio\nfrom kaleido_sdk import KaleidoClient, CreateOrderRequest\n\nasync def main():\n    async with KaleidoClient(\n        api_url=\"https://api.staging.kaleidoswap.com/api/v1\"\n    ) as client:\n        # First get a quote\n        quote = await client.get_quote(\n            from_asset=\"BTC\",\n            to_asset=\"rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak\",\n            amount=1000000\n        )\n        \n        # Create order\n        order = await client.create_order(\n            CreateOrderRequest(\n                rfq_id=quote.rfq_id,\n                from_type=\"ONCHAIN\",\n                to_type=\"LIGHTNING\",\n                from_asset=\"BTC\",\n                to_asset=\"rgb:im7mWgoS-4QX_1b1-DT23iPq-niObDFM-qGN7R2x-lFLJYak\",\n                from_amount=1000000,\n                to_amount=quote.to_amount\n            )\n        )\n        print(f\"Order created: {order.id}\")\n\nasyncio.run(main())"
           }
         ]
       }

--- a/mintlify-docs/whats-kaleidoswap/introduction.mdx
+++ b/mintlify-docs/whats-kaleidoswap/introduction.mdx
@@ -197,7 +197,7 @@ Build on KaleidoSwap with our SDKs and APIs:
 
 <CodeGroup>
 ```typescript TypeScript
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 const client = KaleidoClient.create({
   baseUrl: 'https://api.signet.kaleidoswap.com'
@@ -214,7 +214,7 @@ const quote = await client.maker.getQuote({
 ```
 
 ```python Python
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 client = KaleidoClient.create(
     base_url="https://api.signet.kaleidoswap.com"

--- a/mintlify-docs/whats-kaleidoswap/key-features.mdx
+++ b/mintlify-docs/whats-kaleidoswap/key-features.mdx
@@ -311,7 +311,7 @@ For developers building on KaleidoSwap:
 <Tabs>
   <Tab title="Python SDK">
     ```python
-    from kaleidoswap_sdk import KaleidoClient
+    from kaleido_sdk import KaleidoClient
 
     client = KaleidoClient.create(
         base_url="https://api.signet.kaleidoswap.com"
@@ -328,7 +328,7 @@ For developers building on KaleidoSwap:
 
   <Tab title="TypeScript SDK">
     ```typescript
-    import { KaleidoClient } from 'kaleidoswap-sdk';
+    import { KaleidoClient } from 'kaleido-sdk';
 
     const client = KaleidoClient.create({
       baseUrl: 'https://api.signet.kaleidoswap.com'

--- a/mintlify-docs/whats-kaleidoswap/quickstart.mdx
+++ b/mintlify-docs/whats-kaleidoswap/quickstart.mdx
@@ -137,11 +137,11 @@ description: Get started with KaleidoSwap in minutes
 <CodeGroup>
 
 ```bash Installation
-pip install kaleidoswap-sdk
+pip install kaleido-sdk
 ```
 
 ```python Basic Usage
-from kaleidoswap_sdk import KaleidoClient
+from kaleido_sdk import KaleidoClient
 
 # Initialize client
 client = KaleidoClient.create(
@@ -172,15 +172,15 @@ print(f"Quote received: {quote}")
 <CodeGroup>
 
 ```bash npm
-npm install kaleidoswap-sdk
+npm install kaleido-sdk
 ```
 
 ```bash yarn
-yarn add kaleidoswap-sdk
+yarn add kaleido-sdk
 ```
 
 ```typescript Basic Usage
-import { KaleidoClient } from 'kaleidoswap-sdk';
+import { KaleidoClient } from 'kaleido-sdk';
 
 // Initialize client
 const client = KaleidoClient.create({


### PR DESCRIPTION
Update all import statements, install commands, and code examples to use kaleido-sdk (TS) and kaleido_sdk (Python) instead of the old kaleidoswap-sdk package name.