### PR TITLE
Sync docs with kaleido-sdk v0.1.5 and kaleido-cli updates

### DIFF
--- a/mintlify-docs/cli/channels-lsp.mdx
+++ b/mintlify-docs/cli/channels-lsp.mdx
@@ -102,7 +102,7 @@ These commands are useful before creating orders or when wiring client defaults.
 
 ```bash
 kaleido channel lsp info
-kaleido node taker pubkey
+kaleido node swap pubkey
 kaleido channel order estimate-fees --lsp-balance 1000000 --client-balance 500000
 kaleido channel order create 03abc... --lsp-balance 1000000 --client-balance 500000
 ```

--- a/mintlify-docs/cli/command-reference.mdx
+++ b/mintlify-docs/cli/command-reference.mdx
@@ -32,7 +32,7 @@ kaleido [global options] <command> [subcommand] [args]
 | `peer` | Peer connectivity |
 | `payment` | Lightning and RGB+LN payments |
 | `market` | Market discovery, quotes, and analytics |
-| `swap` | Order, atomic, and local node swap flows |
+| `swap` | Order and atomic swap flows |
 | `config` | Stored CLI configuration |
 
 ## `setup`
@@ -59,16 +59,22 @@ Key flags: `--mode`, `--defaults`, `--api-url`, `--network`, `--node-url`, `--cr
 | `kaleido node logs <name>` | Stream logs |
 | `kaleido node clean <name>` | Delete volumes |
 | `kaleido node info` | Show node details |
+| `kaleido node network` | Show network information |
 | `kaleido node init` | Initialize the wallet |
 | `kaleido node unlock` | Unlock the wallet |
 | `kaleido node lock` | Lock the wallet |
+| `kaleido node shutdown` | Gracefully shut down the node |
 
-### `node taker`
+### `node swap`
 
 | Command | Summary |
 |--------|---------|
-| `kaleido node taker pubkey` | Print the taker public key |
-| `kaleido node taker whitelist <swapstring>` | Accept a swap on the taker side |
+| `kaleido node swap pubkey` | Print the taker public key |
+| `kaleido node swap init` | Start a local maker-init swap flow |
+| `kaleido node swap whitelist` | Whitelist a swap on the taker side |
+| `kaleido node swap execute` | Execute a local node swap |
+| `kaleido node swap status <payment-hash>` | Check local node swap status |
+| `kaleido node swap list` | List swaps known to the node |
 
 ## `wallet`
 
@@ -84,7 +90,6 @@ Key flags: `--mode`, `--defaults`, `--api-url`, `--network`, `--node-url`, `--cr
 | `kaleido wallet restore <path>` | Restore wallet data |
 | `kaleido wallet change-password` | Change wallet password |
 | `kaleido wallet estimate-fee` | Estimate fee rate |
-| `kaleido wallet shutdown` | Gracefully shut down the node |
 
 ## `asset`
 
@@ -124,6 +129,7 @@ Key flags: `--mode`, `--defaults`, `--api-url`, `--network`, `--node-url`, `--cr
 |--------|---------|
 | `kaleido channel order create <client-pubkey>` | Create an LSP channel order |
 | `kaleido channel order get <order-id>` | Fetch order status |
+| `kaleido channel order pay <order-id>` | Pay for a channel order |
 | `kaleido channel order decide <order-id>` | Submit a rate decision |
 | `kaleido channel order estimate-fees` | Estimate channel-order fees |
 
@@ -184,16 +190,6 @@ Key flags: `--mode`, `--defaults`, `--api-url`, `--network`, `--node-url`, `--cr
 | `kaleido swap atomic execute` | Execute the swap |
 | `kaleido swap atomic status <payment-hash>` | Atomic swap status |
 | `kaleido swap atomic run <pair>` | Run the full atomic flow |
-
-### `swap node`
-
-| Command | Summary |
-|--------|---------|
-| `kaleido swap node init` | Start a low-level node swap |
-| `kaleido swap node whitelist` | Whitelist a taker-side swap |
-| `kaleido swap node execute` | Execute the swap |
-| `kaleido swap node status <payment-hash>` | Node swap status |
-| `kaleido swap node list` | List local swaps |
 
 ## `config`
 

--- a/mintlify-docs/cli/market-and-swaps.mdx
+++ b/mintlify-docs/cli/market-and-swaps.mdx
@@ -31,15 +31,15 @@ Important quote options:
 
 Supported layer values include `BTC_LN`, `RGB_LN`, and `BTC_ONCHAIN` for market quotes.
 
-## Three Swap Scopes
+## Swap Scopes
 
-The `swap` group is split by execution model:
+Swaps are split across two command groups:
 
 | Scope | Use case |
 |------|----------|
 | `swap order` | Create and track maker swap orders through the KaleidoSwap server |
 | `swap atomic` | Run maker-backed atomic swaps using your local node as taker |
-| `swap node` | Drive low-level local RLN swap steps directly |
+| `node swap` | Drive low-level local RLN swap steps directly (under the `node` group) |
 
 ## Maker Order Flow
 
@@ -101,15 +101,16 @@ You can also provide:
 
 ## Local Node Swap Flow
 
-Use `swap node` for low-level RLN swap steps:
+Use `node swap` for low-level RLN swap steps (these live under the `node` command group):
 
 | Command | Purpose |
 |--------|---------|
-| `kaleido swap node init` | Start a local maker-init swap flow |
-| `kaleido swap node whitelist` | Whitelist the swap on the taker side |
-| `kaleido swap node execute` | Execute after whitelisting |
-| `kaleido swap node status <payment-hash>` | Inspect status |
-| `kaleido swap node list` | List swaps known to the node |
+| `kaleido node swap pubkey` | Print the taker public key |
+| `kaleido node swap init` | Start a local maker-init swap flow |
+| `kaleido node swap whitelist` | Whitelist the swap on the taker side |
+| `kaleido node swap execute` | Execute after whitelisting |
+| `kaleido node swap status <payment-hash>` | Inspect status |
+| `kaleido node swap list` | List swaps known to the node |
 
 This path is useful for debugging, demos, and lower-level protocol operations where you want each step exposed separately.
 
@@ -127,7 +128,7 @@ kaleido swap order create BTC/USDT --to-amount 5000000 --receiver-address lnbcrt
 
 ```bash
 kaleido node unlock
-kaleido node taker pubkey
+kaleido node swap pubkey
 kaleido swap atomic run BTC/USDT --from-amount 100000 --from-layer BTC_LN --to-layer RGB_LN
 ```
 

--- a/mintlify-docs/cli/node-environments.mdx
+++ b/mintlify-docs/cli/node-environments.mdx
@@ -109,13 +109,13 @@ kaleido node lock
 
 Use `info` to confirm the node is reachable and correctly configured before running wallet, channel, or swap flows.
 
-## Taker Operations
+## Node Swap Operations
 
-The nested `taker` group supports atomic and low-level swap acceptance on the node side:
+The nested `swap` group supports atomic and low-level swap operations on the node side:
 
 ```bash
-kaleido node taker pubkey
-kaleido node taker whitelist '30/rgb:abc.../10/rgb:def.../...'
+kaleido node swap pubkey
+kaleido node swap whitelist '30/rgb:abc.../10/rgb:def.../...'
 ```
 
 ## Recommended Local Flow

--- a/mintlify-docs/cli/wallet-assets-payments.mdx
+++ b/mintlify-docs/cli/wallet-assets-payments.mdx
@@ -28,8 +28,6 @@ kaleido node unlock
 | `kaleido wallet backup <path>` | Create an encrypted wallet backup |
 | `kaleido wallet restore <path>` | Restore from a backup archive |
 | `kaleido wallet change-password` | Rotate the wallet password |
-| `kaleido wallet shutdown` | Gracefully shut down the node |
-
 ### Examples
 
 ```bash

--- a/mintlify-docs/sdk/changelog.mdx
+++ b/mintlify-docs/sdk/changelog.mdx
@@ -7,7 +7,7 @@ description: SDK and API version history for KaleidoSwap
   This changelog covers the KaleidoSwap SDK (`kaleido-sdk`) and the Maker API (`/api/v1`). For desktop app releases, see the [GitHub releases page](https://github.com/kaleidoswap/desktop-app/releases).
 </Note>
 
-## SDK v0.1.2 — Current
+## SDK v0.1.5 — Current
 
 **Environments:** Regtest (`api.regtest.kaleidoswap.com`), Signet (`api.signet.kaleidoswap.com`)
 

--- a/mintlify-docs/sdk/examples.mdx
+++ b/mintlify-docs/sdk/examples.mdx
@@ -306,7 +306,7 @@ import { toSmallestUnits, toDisplayUnits, getSdkName, getVersion } from 'kaleido
 console.log(toSmallestUnits(0.001, 8)); // 100000
 console.log(toDisplayUnits(100000, 8)); // 0.001
 console.log(getSdkName());              // "kaleido-sdk"
-console.log(getVersion());              // "0.1.2"
+console.log(getVersion());              // "0.1.5"
 ```
 
 ```python Python
@@ -315,6 +315,6 @@ from kaleido_sdk import to_smallest_units, to_display_units, get_sdk_name, get_v
 print(to_smallest_units(0.001, 8))  # 100000
 print(to_display_units(100000, 8))  # 0.001
 print(get_sdk_name())               # "kaleido-sdk"
-print(get_version())                # "0.1.2"
+print(get_version())                # "0.1.5"
 ```
 </CodeGroup>

--- a/mintlify-docs/sdk/getting-started.mdx
+++ b/mintlify-docs/sdk/getting-started.mdx
@@ -5,7 +5,7 @@ description: 'Install and configure the Kaleido SDK for TypeScript or Python'
 
 ## Version Compatibility
 
-The current SDK implementation in `kaleido-sdk` (TypeScript) and `kaleido_sdk` (Python) is `v0.1.2`.
+The current SDK implementation in `kaleido-sdk` (TypeScript) and `kaleido_sdk` (Python) is `v0.1.5`.
 
 Both SDKs are generated from the same Maker API and RGB Lightning Node specs, then wrapped with handwritten clients for:
 

--- a/mintlify-docs/sdk/maker-api-compatibility.mdx
+++ b/mintlify-docs/sdk/maker-api-compatibility.mdx
@@ -5,7 +5,7 @@ description: 'SDK and Maker API compatibility information'
 
 ## Compatibility
 
-**SDK v0.1.2** is compatible with the **latest Maker API** version.
+**SDK v0.1.5** is compatible with the **latest Maker API** version.
 
 The SDK automatically supports the most recent Maker API release. Always keep your SDK and Maker API updated to ensure full compatibility and access to the latest features.
 

--- a/mintlify-docs/sdk/rln-api-compatibility.mdx
+++ b/mintlify-docs/sdk/rln-api-compatibility.mdx
@@ -5,7 +5,7 @@ description: 'SDK and RGB Lightning Node API compatibility information'
 
 ## Compatibility
 
-**SDK v0.1.2** is compatible with the **latest RLN (RGB Lightning Node) API** version.
+**SDK v0.1.5** is compatible with the **latest RLN (RGB Lightning Node) API** version.
 
 The SDK automatically supports the most recent RLN API release. Always keep your SDK and RGB Lightning Node updated to ensure full compatibility and access to the latest features and security improvements.
 


### PR DESCRIPTION
## Summary
- Bump SDK version references from v0.1.2 to v0.1.5 across all SDK docs
- Fix CLI command hierarchy: `node taker` and `swap node` → `node swap` (matches actual CLI structure)
- Add missing CLI commands: `node network`, `node shutdown`, `channel order pay`
- Expand `node swap` section from 2 commands to full 6 (pubkey, init, whitelist, execute, status, list)
- Remove ghost `wallet shutdown` command (only exists as `node shutdown` in CLI source)

## Files changed (10)
**SDK (5 files):** getting-started, changelog, examples, maker-api-compatibility, rln-api-compatibility
**CLI (5 files):** command-reference, market-and-swaps, node-environments, channels-lsp, wallet-assets-payments

## Test plan
- [ ] Verify Mintlify build passes
- [ ] Spot-check CLI commands match `kaleido --help` output
- [ ] Confirm SDK version matches published npm/PyPI packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)