### PR TITLE
Document closed beta extension installation

### DIFF
--- a/mintlify-docs/extensions/introduction.mdx
+++ b/mintlify-docs/extensions/introduction.mdx
@@ -30,7 +30,7 @@ KaleidoSwap browser extensions bring wallet management, protocol accounts, swaps
 
 ### KaleidoSwap Extension
 
-The KaleidoSwap Extension is a Chrome and Firefox-compatible wallet extension purpose-built for Bitcoin Layer 2 networks. It starts from one recovery phrase and can derive Spark, Arkade, and Nostr identity state, with RGB Lightning Node support available as an experimental opt-in.
+The KaleidoSwap Extension is a browser wallet purpose-built for Bitcoin Layer 2 networks. The first closed beta is distributed to invited testers as a private Developer Mode zip, before browser-store listings and the public source release. It starts from one recovery phrase and can derive Spark, Arkade, and Nostr identity state, with RGB Lightning Node support available as an experimental opt-in.
 
 <img src="/images/kaleidoswap-extension/08-dashboard.png" alt="KaleidoSwap Extension dashboard" style={{ maxWidth: "360px", width: "100%", height: "auto" }} />
 

--- a/mintlify-docs/extensions/kaleidoswap-extension/faq.mdx
+++ b/mintlify-docs/extensions/kaleidoswap-extension/faq.mdx
@@ -7,10 +7,11 @@ description: Common questions and solutions for the KaleidoSwap Extension
 
 <AccordionGroup>
   <Accordion title="What browsers does the KaleidoSwap Extension support?">
-    The KaleidoSwap Extension is available on:
-    - Chromium-based browsers such as Google Chrome, Brave, Microsoft Edge, and Opera
-    - Firefox and Zen Browser
-    - Safari is not yet supported
+    The first closed beta targets Chromium-based browsers such as Google Chrome, Brave, Microsoft Edge, and Opera through Developer Mode installation from a private beta zip. Firefox support may be tested separately when a Firefox build is provided. Safari is not yet supported.
+  </Accordion>
+
+  <Accordion title="Where do I get the closed beta build?">
+    Invited testers receive a private Drive link from the KaleidoSwap team. The extension is not listed in browser stores yet, and the source repository is not public yet, so closed beta testers should install only the zip shared through the official invite or support channel.
   </Accordion>
 
   <Accordion title="Do I need my own node?">

--- a/mintlify-docs/extensions/kaleidoswap-extension/installation.mdx
+++ b/mintlify-docs/extensions/kaleidoswap-extension/installation.mdx
@@ -5,54 +5,38 @@ description: Install or load the KaleidoSwap Extension
 
 ## Browser Requirements
 
-The KaleidoSwap Extension is built as a Manifest V3 web extension.
+The KaleidoSwap Extension is built as a Manifest V3 web extension. The first closed beta is distributed as a Chromium-compatible zip archive for Developer Mode installation.
 
 | Browser | Supported |
 |---------|-----------|
-| **Google Chrome** | Yes, Chromium extension support |
-| **Brave** | Yes, Chromium extension support |
-| **Edge** | Yes, Chromium extension support |
-| **Opera** | Yes, Chromium extension support |
-| **Firefox** | Supported by the manifest gecko configuration |
+| **Google Chrome** | Closed beta target |
+| **Brave** | Closed beta target |
+| **Edge** | Closed beta target |
+| **Opera** | Closed beta target |
+| **Firefox** | Not part of the first closed beta unless a Firefox build is provided |
 | **Safari** | Not yet |
 
 ## Installation
 
-### From a Browser Store
+### Closed Beta Zip (Developer Mode)
 
-When a browser-store build is available, install it from the KaleidoSwap Extension listing for your browser and pin the extension icon in the toolbar.
+The first KaleidoSwap Extension release is an invite-only closed beta. There is no browser-store listing yet, and the extension source repository is not public yet. Invited testers receive a private Drive link from the KaleidoSwap team with the beta zip, checksum, and release notes.
 
-<Steps>
-  <Step title="Open the Store Listing">
-    Open the KaleidoSwap Extension listing for your browser.
-  </Step>
-  <Step title="Install the Extension">
-    Confirm the browser installation prompt.
-  </Step>
-  <Step title="Pin the Extension">
-    Pin KaleidoSwap from the extensions menu so the wallet is available from the toolbar.
-  </Step>
-</Steps>
-
-### Manual Installation (Developer Mode)
-
-Use manual installation when testing a pre-release build or building from source.
+<Warning>
+Only install beta archives shared through the official KaleidoSwap invite or support channel. Do not install forwarded archives from unverified sources.
+</Warning>
 
 <Steps>
-  <Step title="Build the Extension">
-    First, download or clone the KaleidoSwap Extension source code, then open a terminal in the project root directory. If `pnpm` is not installed yet, install it first, then install dependencies and build:
+  <Step title="Download the Beta Zip">
+    Open the private Drive link from your beta invite and download the latest KaleidoSwap Extension zip archive. If a checksum is provided, verify it before installing.
+  </Step>
 
-    ```bash
-    git clone <repository-url>
-    cd <repository-directory>
-    npm install -g pnpm
-    pnpm install
-    pnpm run build
-    ```
+  <Step title="Extract the Archive">
+    Unzip the archive into a stable folder on your machine. Keep this extracted folder in place while the extension is installed, because the browser loads the extension from that folder.
   </Step>
 
   <Step title="Open Extensions Page">
-    Navigate to `chrome://extensions` in your browser.
+    Navigate to `chrome://extensions` in your Chromium-based browser.
   </Step>
 
   <Step title="Enable Developer Mode">
@@ -60,13 +44,24 @@ Use manual installation when testing a pre-release build or building from source
   </Step>
 
   <Step title="Load Unpacked">
-    Click **Load unpacked** and select the `dist` folder from the build output.
+    Click **Load unpacked** and select the extracted folder that contains `manifest.json`. If the archive contains a `dist` folder, select `dist`.
   </Step>
 
   <Step title="Pin the Extension">
     Pin the KaleidoSwap icon in your toolbar for easy access.
   </Step>
 </Steps>
+
+## Not Available Yet
+
+| Channel | Status |
+|---------|--------|
+| **Browser stores** | Not available during the first closed beta |
+| **Source build** | Not available until the extension source is opened |
+
+<Note>
+Closed beta testers should install only the zip provided through the private Drive link. Source-build instructions will be added when the extension repository is made public.
+</Note>
 
 ## First Launch
 
@@ -101,7 +96,7 @@ The KaleidoSwap Extension stores the encrypted mnemonic in `chrome.storage.local
 
 ## Updating
 
-Store-installed builds update through the browser's extension update system. For manual installations, pull the latest code, rebuild, and reload the unpacked extension in your browser.
+Closed beta builds do not auto-update through a browser store. When a new beta is available, download the latest zip from the private Drive link, extract it, then return to `chrome://extensions` and click **Reload** on the KaleidoSwap Extension card. If you extracted the new build into a different folder, remove the old unpacked extension and load the new folder.
 
 ## Uninstalling
 

--- a/mintlify-docs/web-app/getting-started.mdx
+++ b/mintlify-docs/web-app/getting-started.mdx
@@ -22,7 +22,7 @@ The KaleidoSwap Web App is available at:
     | **Alby** | Lightning-native wallet | [getalby.com](https://getalby.com) |
     | **Xverse** | Bitcoin Web3 wallet | [xverse.app](https://xverse.app) |
     | **BitMask** | RGB & Lightning wallet | [bitmask.app](https://bitmask.app) |
-    | **KaleidoSwap Extension** | Bitcoin Layer 2 extension | [KaleidoSwap Extension](/extensions/kaleidoswap-extension/installation) |
+    | **KaleidoSwap Extension** | Bitcoin Layer 2 extension, closed beta by invite | [KaleidoSwap Extension](/extensions/kaleidoswap-extension/installation) |
   </Step>
 
   <Step title="Fund Your Wallet">

--- a/mintlify-docs/web-app/wallet-connection.mdx
+++ b/mintlify-docs/web-app/wallet-connection.mdx
@@ -24,9 +24,9 @@ The KaleidoSwap Web App supports multiple Bitcoin wallet extensions:
     [Install BitMask](https://bitmask.app)
   </Card>
   <Card title="KaleidoSwap Extension" icon="puzzle-piece">
-    Bitcoin Layer 2 extension with built-in RGB, swap, and DApp support
+    Bitcoin Layer 2 extension with built-in RGB, swap, and DApp support. Closed beta access is invite-only.
     
-    [Install the KaleidoSwap Extension](/extensions/kaleidoswap-extension/installation)
+    [Install the KaleidoSwap Extension closed beta](/extensions/kaleidoswap-extension/installation)
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
## Summary

- Replace browser-store/source-build extension install flow with invite-only Drive zip installation
- Add closed beta availability notes in extension overview, FAQ, and web-app wallet entry points
- Clarify beta updates through reloading unpacked builds rather than store auto-updates

## Testing

- Searched docs for stale browser-store/source-build install wording