### PR TITLE
docs(sdk): kaleido-sdk 0.1.9 (RLN 0.7.1 + NWC)

### DIFF
--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -149,7 +149,8 @@
             "pages": [
               "sdk/api-reference",
               "sdk/types",
-              "sdk/websocket"
+              "sdk/websocket",
+              "sdk/nwc"
             ]
           },
           {

--- a/mintlify-docs/sdk/changelog.mdx
+++ b/mintlify-docs/sdk/changelog.mdx
@@ -7,7 +7,31 @@ description: SDK and API version history for KaleidoSwap
   This changelog covers the KaleidoSwap SDK (`kaleido-sdk`) and the Maker API (`/api/v1`). For desktop app releases, see the [GitHub releases page](https://github.com/kaleidoswap/desktop-app/releases).
 </Note>
 
-## SDK v0.1.5 — Current
+## SDK v0.1.9 — Current
+
+**Environments:** Regtest (`api.regtest.kaleidoswap.com`), Signet (`api.signet.kaleidoswap.com`)
+
+**Compatible APIs:** Latest Maker API · RLN (RGB Lightning Node) API **v0.7.1**
+
+### Added
+
+- **NWC (Nostr Wallet Connect, NIP-47) client** — new `kaleido-sdk/nwc` subpath. `NWCClient` exposes `rln_*` RLN extension methods and an `RlnTransport` seam that runs the RLN client over an NWC connection (NIP-44 encryption, NIP-04 fallback). LN-invoice decode, send-BTC and list-payments are mapped over the NWC transport.
+- RLN client methods + models for `POST /sendrgb`, `POST /inflate`, `POST /issueassetifa`, and Inflatable Fungible Asset (IFA) types.
+
+### Changed
+
+- Regenerated the RLN models against `kaleidoswap/rgb-lightning-node` **v0.7.1**.
+
+### Breaking changes
+
+- `ListUnspentsRequest` now requires `settled_only`. RLN 0.7.1 rejects the old `{skip_sync}`-only body with `HTTP 400 "Failed to deserialize the JSON body into the target type"`. The `list_unspents()` convenience method defaults `settled_only=False`; callers that build the request directly must set it.
+- `POST /sendasset` was renamed to `POST /sendrgb` (`SendAssetRequest`/`SendAssetResponse` → `SendRgbRequest`/`SendRgbResponse`).
+
+<Note>
+  Versions 0.1.6–0.1.8 are omitted here; see the full [CHANGELOG](https://github.com/kaleidoswap/kaleido-sdk/blob/master/CHANGELOG.md) in the SDK repository.
+</Note>
+
+## SDK v0.1.5
 
 **Environments:** Regtest (`api.regtest.kaleidoswap.com`), Signet (`api.signet.kaleidoswap.com`)
 

--- a/mintlify-docs/sdk/nwc.mdx
+++ b/mintlify-docs/sdk/nwc.mdx
@@ -1,0 +1,89 @@
+---
+title: 'Nostr Wallet Connect (NWC)'
+description: 'Control a remote RGB Lightning Node over Nostr Wallet Connect (NIP-47) with the kaleido-sdk/nwc client'
+---
+
+## Overview
+
+Since **kaleido-sdk 0.1.9**, the SDK ships a **Nostr Wallet Connect (NIP-47)** client on the
+`kaleido-sdk/nwc` subpath. It lets a client app drive a remote wallet service — for example the
+KaleidoSwap desktop hub running an RGB Lightning Node — over a Nostr relay, without a direct HTTP
+connection to the node.
+
+On top of the standard NIP-47 wallet methods, the client adds **`rln*` RGB Lightning extension
+methods** so you can read balances, manage RGB assets, and open invoices on the remote node through
+the same encrypted NWC transport.
+
+<Info>
+  Transport is end-to-end encrypted with **NIP-44**, falling back to **NIP-04** when the wallet
+  service does not advertise NIP-44 support.
+</Info>
+
+## Connecting
+
+You need an NWC **connection URI** (`nostr+walletconnect://...`) issued by the wallet service.
+
+```ts
+import { NWCClient } from 'kaleido-sdk/nwc';
+
+const nwc = new NWCClient(connectionUri);
+
+const { balance } = await nwc.getBalance();
+console.log('balance (msat):', balance);
+
+// release the relay subscription when done
+nwc.close();
+```
+
+`parseNwcUri(uri)` is exported if you need to inspect a URI (relay, wallet pubkey, secret) before
+connecting, and `NwcError` is thrown on protocol/timeout failures.
+
+## Standard wallet methods (NIP-47)
+
+```ts
+await nwc.getInfo();                              // capabilities / supported methods
+await nwc.getBalance();                           // { balance } in msat
+await nwc.makeInvoice({ amount, description });    // create a BOLT11 invoice
+await nwc.payInvoice({ invoice });                 // pay a BOLT11 invoice
+await nwc.payKeysend({ pubkey, amount });          // spontaneous payment
+await nwc.lookupInvoice({ payment_hash });         // invoice status
+await nwc.listTransactions({ limit, offset });     // payment history
+```
+
+## RGB Lightning Node extension methods
+
+These map RLN operations over the same NWC connection:
+
+```ts
+await nwc.rlnNodeInfo();                 // NodeInfoResponse
+await nwc.rlnListAssets();               // ListAssetsResponse
+await nwc.rlnAssetBalance({ asset_id }); // AssetBalanceResponse
+await nwc.rlnGetAddress();               // on-chain address
+await nwc.rlnListChannels();             // ListChannelsResponse
+await nwc.rlnRgbInvoice(params);         // create an RGB invoice
+await nwc.rlnDecodeRgbInvoice({ invoice });
+await nwc.rlnSendAsset(params);          // SendRgbRequest -> SendRgbResponse
+```
+
+## Running the full RLN client over NWC
+
+If you already use the [`RlnClient`](/sdk/api-reference) against an HTTP `nodeUrl`, you can swap the
+transport for NWC instead — same client surface, routed over Nostr:
+
+```ts
+import { createNwcRlnClient } from 'kaleido-sdk/nwc';
+
+const rln = createNwcRlnClient(connectionUri);
+const info = await rln.getNodeInfo();
+const channels = await rln.listChannels();
+```
+
+`NwcRlnNodeClient` is the underlying transport if you need to construct it directly.
+
+## When to use NWC vs HTTP
+
+| | HTTP (`nodeUrl`) | NWC |
+| --- | --- | --- |
+| Connectivity | Direct reachability to the node's REST API | Works through a Nostr relay — no inbound port / public node URL needed |
+| Auth | API key / Authorization header | NWC connection secret, encrypted (NIP-44/04) |
+| Best for | Server-side and same-network integrations | Remote control of a user's node (e.g. the desktop hub) over the open internet |

--- a/mintlify-docs/sdk/rln-api-compatibility.mdx
+++ b/mintlify-docs/sdk/rln-api-compatibility.mdx
@@ -9,13 +9,6 @@ description: 'SDK and RGB Lightning Node API compatibility information'
 
 The SDK automatically supports the most recent RLN API release. Always keep your SDK and RGB Lightning Node updated to ensure full compatibility and access to the latest features and security improvements.
 
-<Warning>
-  RLN v0.7.1 introduced breaking request-schema changes that require **SDK v0.1.9+**:
-  - `ListUnspentsRequest` now requires a `settled_only` field (older SDKs send only `{skip_sync}` and get `HTTP 400 "Failed to deserialize the JSON body into the target type"`).
-  - `POST /sendasset` was renamed to `POST /sendrgb`.
-  - New endpoints: `POST /inflate`, `POST /issueassetifa` (Inflatable Fungible Assets).
-</Warning>
-
 <Note>
 To check the latest RLN API changes and updates, refer to the [RGB Lightning Node](https://github.com/kaleidoswap/rgb-lightning-node) or your node documentation.
 </Note>

--- a/mintlify-docs/sdk/rln-api-compatibility.mdx
+++ b/mintlify-docs/sdk/rln-api-compatibility.mdx
@@ -5,12 +5,19 @@ description: 'SDK and RGB Lightning Node API compatibility information'
 
 ## Compatibility
 
-**SDK v0.1.5** is compatible with the **latest RLN (RGB Lightning Node) API** version.
+**SDK v0.1.9** is generated against **RGB Lightning Node API v0.7.1** (the `kaleidoswap/rgb-lightning-node` fork).
 
 The SDK automatically supports the most recent RLN API release. Always keep your SDK and RGB Lightning Node updated to ensure full compatibility and access to the latest features and security improvements.
 
+<Warning>
+  RLN v0.7.1 introduced breaking request-schema changes that require **SDK v0.1.9+**:
+  - `ListUnspentsRequest` now requires a `settled_only` field (older SDKs send only `{skip_sync}` and get `HTTP 400 "Failed to deserialize the JSON body into the target type"`).
+  - `POST /sendasset` was renamed to `POST /sendrgb`.
+  - New endpoints: `POST /inflate`, `POST /issueassetifa` (Inflatable Fungible Assets).
+</Warning>
+
 <Note>
-To check the latest RLN API changes and updates, refer to the [RGB Lightning Node](https://github.com/RGB-Tools/rgb-lightning-node) or your node documentation.
+To check the latest RLN API changes and updates, refer to the [RGB Lightning Node](https://github.com/kaleidoswap/rgb-lightning-node) or your node documentation.
 </Note>
 
 ## RLN API Overview


### PR DESCRIPTION
Documents the **kaleido-sdk 0.1.9** release:
- `sdk/changelog.mdx`: new `v0.1.9 — Current` entry — NWC (NIP-47) client (`kaleido-sdk/nwc` subpath), `/sendrgb`, `/inflate`, `/issueassetifa`, IFA; breaking changes (`ListUnspentsRequest.settled_only`, `/sendasset`→`/sendrgb`).
- `sdk/rln-api-compatibility.mdx`: bumped to RLN **v0.7.1** + a breaking-change warning; repointed the RLN link to the kaleidoswap fork.

Note: the docs were at v0.1.5; 0.1.6–0.1.8 are not backfilled here (the SDK repo CHANGELOG is authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)